### PR TITLE
Fix: prevent EC write flood in SmartFnLockController (#111)

### DIFF
--- a/LenovoLegionToolkit.Lib/Controllers/SmartFnLockController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/SmartFnLockController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Win32;
 using Windows.Win32.UI.Input.KeyboardAndMouse;
@@ -13,7 +14,7 @@ namespace LenovoLegionToolkit.Lib.Controllers;
 public class SmartFnLockController(FnLockFeature feature, ApplicationSettings settings)
 {
     private readonly AsyncLock _lock = new();
-
+    private CancellationTokenSource _cts = new();
     private bool _ctrlDepressed;
     private bool _shiftDepressed;
     private bool _altDepressed;
@@ -24,12 +25,24 @@ public class SmartFnLockController(FnLockFeature feature, ApplicationSettings se
         if (settings.Store.SmartFnLockFlags == 0)
             return;
 
+        _cts.Cancel();
+        _cts = new CancellationTokenSource();
+        var token = _cts.Token;
+
         Task.Run(async () =>
         {
             try
             {
+                if (token.IsCancellationRequested)
+                    return;
+
                 using (await _lock.LockAsync().ConfigureAwait(false))
+                {
+                    if (token.IsCancellationRequested)
+                        return;
+
                     await OnKeyboardEventAsync(wParam, kbStruct).ConfigureAwait(false);
+                }
             }
             catch (Exception ex)
             {
@@ -50,14 +63,12 @@ public class SmartFnLockController(FnLockFeature feature, ApplicationSettings se
                 return;
 
             Log.Instance.Trace($"Disabling Fn Lock temporarily...");
-
             await feature.SetStateAsync(FnLockState.Off).ConfigureAwait(false);
             _restoreFnLock = true;
         }
         else if (_restoreFnLock)
         {
             Log.Instance.Trace($"Re-enabling Fn Lock...");
-
             await feature.SetStateAsync(FnLockState.On).ConfigureAwait(false);
             _restoreFnLock = false;
         }
@@ -70,10 +81,8 @@ public class SmartFnLockController(FnLockFeature feature, ApplicationSettings se
 
         if (vkKeyCode is VIRTUAL_KEY.VK_LCONTROL or VIRTUAL_KEY.VK_RCONTROL)
             _ctrlDepressed = isKeyDown;
-
         if (vkKeyCode is VIRTUAL_KEY.VK_LSHIFT or VIRTUAL_KEY.VK_RSHIFT)
             _shiftDepressed = isKeyDown;
-
         if (vkKeyCode is VIRTUAL_KEY.VK_LMENU or VIRTUAL_KEY.VK_RMENU)
             _altDepressed = isKeyDown;
 
@@ -85,15 +94,12 @@ public class SmartFnLockController(FnLockFeature feature, ApplicationSettings se
 
         if (flags.HasFlag(ModifierKey.Ctrl))
             result |= _ctrlDepressed;
-
         if (flags.HasFlag(ModifierKey.Shift))
             result |= _shiftDepressed;
-
         if (flags.HasFlag(ModifierKey.Alt))
             result |= _altDepressed;
 
         Log.Instance.Trace($"Modifier key is depressed: {result} [ctrl={_ctrlDepressed}, shift={_shiftDepressed}, alt={_altDepressed}, flags={flags}]");
-
         return result;
     }
 }


### PR DESCRIPTION
## Description
Prevents the ~6 second system freeze caused by rapid modifier key presses 
when Smart Fn Lock is enabled.

- Fixes #111

**Root cause:** Every keypress fired a new `Task.Run` that queued an EC 
write behind `AsyncLock`. With rapid Alt+Tab, dozens of tasks piled up and 
executed sequentially — each making a full `GetStateAsync()` + 
`SetStateAsync()` driver call. Since `FnLockFeature` uses 
`useDriverQueue: true`, all these calls queued up in the driver, 
overwhelming the EC and causing the freeze.

**Fix:** Added a `CancellationTokenSource` that cancels any pending task 
when a new keypress arrives, so only the latest key state ever reaches the 
driver queue.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Hardware Verification Details
- **Device Series:** Legion 5
- **Exact Model Number:** 15AKP10 (83F1)
- **BIOS Version:** RYCN28WW
- **Operating System:** Windows 11 25H2 (OS Build 26200.8037)

## Testing Checklist
- [x] I have verified this change on physical hardware.
- [x] My code follows the project's style guidelines.

## Additional Notes
Tested by rapidly Alt+Tabbing for 15-20 seconds while audio was playing 
with Smart Fn Lock enabled. No freeze occurred after the fix.