### PR TITLE
Add Toggle OSD option to Smart Key Action

### DIFF
--- a/LenovoLegionToolkit.WPF/Utils/SmartKeyHelper.cs
+++ b/LenovoLegionToolkit.WPF/Utils/SmartKeyHelper.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -89,7 +89,11 @@ internal class SmartKeyHelper
         }
 
         if (currentGuid.Value == Guid.Empty)
+        {
+            Log.Instance.Trace($"Toggling OSD after {(isDoublePress ? "double" : "single")} Fn+F9 press.");
+            MessagingCenter.Publish(new OsdChangedMessage(OsdState.Toggle));
             return;
+        }
 
         if (actionList.IsEmpty())
             actionList.Add(currentGuid.Value);

--- a/LenovoLegionToolkit.WPF/Windows/Settings/SelectSmartKeyPipelinesWindow.xaml
+++ b/LenovoLegionToolkit.WPF/Windows/Settings/SelectSmartKeyPipelinesWindow.xaml
@@ -1,4 +1,4 @@
-﻿<local:BaseWindow
+<local:BaseWindow
     x:Class="LenovoLegionToolkit.WPF.Windows.Settings.SelectSmartKeyPipelinesWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -56,15 +56,27 @@
                 <RowDefinition Height="*" />
             </Grid.RowDefinitions>
 
-            <custom:CardControl Grid.Row="0" Margin="0,0,0,24">
-                <custom:CardControl.Header>
-                    <controls:CardHeaderControl Title="{x:Static resources:Resource.SelectSmartKeyPipelinesWindow_ShowThisApp}" />
-                </custom:CardControl.Header>
-                <wpfui:ToggleSwitch
-                    x:Name="_showThisAppToggle"
-                    AutomationProperties.Name="{x:Static resources:Resource.SelectSmartKeyPipelinesWindow_ShowThisApp}"
-                    Click="ShowThisAppToggle_Click" />
-            </custom:CardControl>
+            <StackPanel Grid.Row="0" Margin="0,0,0,24">
+                <custom:CardControl Margin="0,0,0,8">
+                    <custom:CardControl.Header>
+                        <controls:CardHeaderControl Title="{x:Static resources:Resource.SelectSmartKeyPipelinesWindow_ShowThisApp}" />
+                    </custom:CardControl.Header>
+                    <wpfui:ToggleSwitch
+                        x:Name="_showThisAppToggle"
+                        AutomationProperties.Name="{x:Static resources:Resource.SelectSmartKeyPipelinesWindow_ShowThisApp}"
+                        Click="ShowThisAppToggle_Click" />
+                </custom:CardControl>
+
+                <custom:CardControl Margin="0,0,0,0">
+                    <custom:CardControl.Header>
+                        <controls:CardHeaderControl Title="{x:Static resources:Resource.SettingsPage_Osd_Title}" />
+                    </custom:CardControl.Header>
+                    <wpfui:ToggleSwitch
+                        x:Name="_toggleOsdToggle"
+                        AutomationProperties.Name="{x:Static resources:Resource.SettingsPage_Osd_Title}"
+                        Click="ToggleOsdToggle_Click" />
+                </custom:CardControl>
+            </StackPanel>
 
             <TextBlock
                 Grid.Row="1"

--- a/LenovoLegionToolkit.WPF/Windows/Settings/SelectSmartKeyPipelinesWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Settings/SelectSmartKeyPipelinesWindow.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -60,6 +60,7 @@ public partial class SelectSmartKeyPipelinesWindow
         _loader.IsLoading = true;
 
         _showThisAppToggle.IsChecked = SettingsStoreGuid is null;
+        _toggleOsdToggle.IsChecked = SettingsStoreGuid == Guid.Empty;
 
         var allPipelines = await _automationProcessor.GetPipelinesAsync();
         var pipelines = allPipelines.Where(p => p.Trigger is null).OrderBy(p => p.Name).ToArray();
@@ -83,9 +84,19 @@ public partial class SelectSmartKeyPipelinesWindow
         _loader.IsLoading = false;
     }
 
-    private void ShowThisAppToggle_Click(object sender, RoutedEventArgs e) => EnableListIfPossible();
+    private void ShowThisAppToggle_Click(object sender, RoutedEventArgs e)
+    {
+        if (_showThisAppToggle.IsChecked ?? false) _toggleOsdToggle.IsChecked = false;
+        EnableListIfPossible();
+    }
 
-    private void EnableListIfPossible() => _list.IsEnabled = !(_showThisAppToggle.IsChecked ?? false);
+    private void ToggleOsdToggle_Click(object sender, RoutedEventArgs e)
+    {
+        if (_toggleOsdToggle.IsChecked ?? false) _showThisAppToggle.IsChecked = false;
+        EnableListIfPossible();
+    }
+
+    private void EnableListIfPossible() => _list.IsEnabled = !(_showThisAppToggle.IsChecked ?? false) && !(_toggleOsdToggle.IsChecked ?? false);
 
     private void SaveButton_Click(object sender, RoutedEventArgs e)
     {
@@ -98,6 +109,8 @@ public partial class SelectSmartKeyPipelinesWindow
 
         if (_showThisAppToggle.IsChecked ?? false)
             SettingsStoreGuid = null;
+        else if (_toggleOsdToggle.IsChecked ?? false)
+            SettingsStoreGuid = Guid.Empty;
         else
         {
             SettingsStoreList.AddRange(selectedPipelines);


### PR DESCRIPTION
# Pull Request

## Description
I wanted a way to toggle the OSD on and off in-game. I figured the Smart Action key would work pretty well for that.  

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility update (adding support for new hardware)
- [ ] Documentation update

## Hardware Verification Details
Since LLT interacts directly with BIOS and WMI, we require details on where this was tested.

- **Device Series:** Lenovo Legion 5
- **Exact Model Number:** 15AKP10 


- **BIOS Version:** Newest
- **Operating System:** Windows 11 25H2

## Testing Checklist
- [X] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [X] I have verified this change on physical hardware.
- [X] I have included a video/screenshot of the change in action (highly preferred for UI changes).
- [X] My code follows the project's style guidelines.

## Additional Notes
<img width="584" height="737" alt="image" src="https://github.com/user-attachments/assets/73a52e55-e6db-4f55-8dea-70f428d5c83a" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OSD (On-Screen Display) toggle control to SmartKey settings, enabling users to configure on-screen display toggling as a SmartKey action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->