### PR TITLE
Fix dwm.exe and explorer.exe being force-killable from the discrete GPU management window

### DIFF
--- a/LenovoLegionToolkit.Lib/Extensions/PhyscialGPUExtensions.cs
+++ b/LenovoLegionToolkit.Lib/Extensions/PhyscialGPUExtensions.cs
@@ -15,20 +15,23 @@ public static class NVAPIExtensions
         "explorer.exe",
     ];
 
+    public static bool IsExcluded(string processName) =>
+        Exclusions.Contains(processName, StringComparer.InvariantCultureIgnoreCase);
+
     public static (List<Process> All, List<Process> Filtered) GetActiveProcesses(PhysicalGPU gpu)
     {
         var allProcesses = new List<Process>();
         var filteredProcesses = new List<Process>();
         var apps = GPUApi.QueryActiveApps(gpu.Handle);
-        
+
         foreach (var app in apps)
         {
             try
             {
                 var process = Process.GetProcessById(app.ProcessId);
                 allProcesses.Add(process);
-                
-                if (!Exclusions.Contains(app.ProcessName, StringComparer.InvariantCultureIgnoreCase))
+
+                if (!IsExcluded(app.ProcessName))
                 {
                     filteredProcesses.Add(process);
                 }

--- a/LenovoLegionToolkit.WPF/Windows/Dashboard/DiscreteGPUManagementWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Dashboard/DiscreteGPUManagementWindow.xaml.cs
@@ -10,6 +10,7 @@ using System.Windows;
 using System.Windows.Controls;
 using LenovoLegionToolkit.Lib;
 using LenovoLegionToolkit.Lib.Controllers;
+using LenovoLegionToolkit.Lib.Extensions;
 using LenovoLegionToolkit.Lib.Settings;
 using LenovoLegionToolkit.Lib.System;
 using LenovoLegionToolkit.Lib.Utils;
@@ -124,6 +125,7 @@ public partial class DiscreteGPUManagementWindow : BaseWindow
                         ProcessIds = processIds,
                         Preference = preference,
                         IsPreferenceEnabled = hasMultipleGpus,
+                        IsProtected = NVAPIExtensions.IsExcluded(System.IO.Path.GetFileName(path)),
                         Icon = icon
                     });
                 }
@@ -225,6 +227,9 @@ public partial class DiscreteGPUManagementWindow : BaseWindow
     {
         if (sender is MenuItem menuItem && menuItem.CommandParameter is List<int> pids)
         {
+            if (menuItem.DataContext is DiscreteGPUAppViewModel { IsProtected: true })
+                return;
+
             foreach (var pid in pids)
             {
                 try
@@ -250,7 +255,8 @@ public class DiscreteGPUAppViewModel : INotifyPropertyChanged
     public bool IsPreferenceEnabled { get; set; }
 
     public List<int> ProcessIds { get; set; } = [];
-    public bool CanKill => IsActive && ProcessIds.Count > 0;
+    public bool IsProtected { get; set; }
+    public bool CanKill => IsActive && ProcessIds.Count > 0 && !IsProtected;
 
     private bool _isActive;
     public bool IsActive


### PR DESCRIPTION
## Description
The Discrete GPU Management window's "Force Kill Process" context menu allowed killing any process in the active-on-dGPU list, including `dwm.exe` and `explorer.exe`. Killing `dwm.exe` causes Windows to restart the desktop compositor, and LLT's WPF main window loses visibility on the new compositor session — leaving the app running with no usable UI (the symptom in #286).

`NVAPIExtensions` already maintains an exclusion list (`dwm.exe`, `explorer.exe`) for the GPU-deactivation flow but it wasn't applied to the management window's per-app context menu. This PR exposes the existing list as `NVAPIExtensions.IsExcluded(processName)`, sets `IsProtected` on the corresponding view-model entries, and folds it into `CanKill` so the existing `IsEnabled="{Binding CanKill}"` binding greys out the menu item. The click handler also bails if the source view-model is protected (defense-in-depth against any XAML binding race).

No new resource keys, XAML, or localization changes. Set of protected names matches the list already used by `KillGPUProcessesAsync`.

- Fixes #286

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility update (adding support for new hardware)
- [ ] Documentation update

## Hardware Verification Details
- **Device Series:** Legion 5
- **Exact Model Number:** Legion 5 15AHP11 (machine type 83Q7)
- **BIOS Version:** T2CN33WW
- **Operating System:** Windows 11 Enterprise LTSC, 24H2 (build 26100.8246), x64

## Testing Checklist
- [x] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [x] I have verified this change on physical hardware.
- [ ] I have included a video/screenshot of the change in action (highly preferred for UI changes).
- [x] My code follows the project's style guidelines.

## Additional Notes
Built against current `master` (1d89c867); `dotnet build` clean with no new warnings. Discrete GPU Management window opens correctly and existing kill behaviour on user processes is unchanged.

Visual verification of the greyed-out menu specifically on `dwm.exe`/`explorer.exe` couldn't be reproduced on this Legion 5 15AHP11 because under default hybrid-graphics state (no external monitor wired through the dGPU, no Windows Graphics Settings override forcing dwm to High-performance) neither process surfaces in the active-dGPU list — the precondition for #286 isn't naturally present here. The original reporter's setup (Legion 5 15ach) does trigger it. Happy to follow up with a video if a reviewer hits it on a setup that surfaces dwm in the list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Applications designated as protected are now excluded from manual termination in the discrete GPU management interface, preventing accidental termination of critical processes.

* **Bug Fixes**
  * Improved process management reliability by preventing exclusion-listed applications from being forcefully terminated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->