### PR TITLE
Auto-detect LampArray devices and surface the Dynamic Lighting feature without a debug flag

### DIFF
--- a/LenovoLegionToolkit.Lib/Utils/AppFlags.cs
+++ b/LenovoLegionToolkit.Lib/Utils/AppFlags.cs
@@ -77,7 +77,7 @@ public class AppFlags
     public bool EnableLampArray
     {
         get => _enableLampArray;
-        set { EnableLampArray = value; Save(); }
+        set { _enableLampArray = value; Save(); }
     }
 
     private bool _experimentalGPUWorkingMode;

--- a/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
@@ -18,6 +18,8 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
+using Windows.Devices.Enumeration;
+using Windows.Devices.Lights;
 using Wpf.Ui.Controls;
 using Button = System.Windows.Controls.Button;
 using WinUIColor = Windows.UI.Color;
@@ -74,15 +76,14 @@ public partial class LampArrayRGBKeyboardPage : UiPage
         try
         {
             if (AppFlags.Instance.EnableLampArray)
-            {
                 return true;
-            }
 
-            return false;
+            var devices = await DeviceInformation.FindAllAsync(LampArray.GetDeviceSelector());
+            return devices.Count > 0;
         }
         catch (Exception ex)
         {
-            Log.Instance.Trace($"Error checking keyboard support: {ex.Message}");
+            Log.Instance.Trace($"Error checking LampArray support: {ex.Message}");
             return false;
         }
     }


### PR DESCRIPTION
## Description
Two related changes that complete the LampArray (Microsoft Dynamic Lighting) integration so it auto-enables on devices that expose a LampArray HID, instead of being hidden behind a developer-only `--enable-lamp-array` argument. Addresses Metanome's note in #247 — *"Dynamic lighting itself isn't complete yet"* — by closing the device-discovery gap; the rest of the LampArray stack (controller, watcher, 12 effects, screen-sync Aurora, per-key custom patterns, JSON profiles, lamp probe) was already in place.

**1. Bug fix — `AppFlags.EnableLampArray` setter infinite recursion** (`AppFlags.cs:80`)
The setter wrote to itself: `set { EnableLampArray = value; Save(); }`. Setting the property would recurse and `StackOverflowException`. Only didn't blow up in production because the field was being written directly from CLI-arg parsing (`_enableLampArray = BoolValue(...)`), bypassing the property. Fixed to write the backing field.

**2. Real device discovery in `LampArrayRGBKeyboardPage.IsSupportedAsync`**
Replaced the debug-flag-only check with `DeviceInformation.FindAllAsync(LampArray.GetDeviceSelector())` — the same Microsoft-recommended discovery the existing `LampArrayController.StartAsync` already uses for its `DeviceWatcher`. The `--enable-lamp-array` flag is preserved as a force-enable override for testing but is no longer required for normal users.

Net effect: any Legion (or other Lenovo machine LLT supports) whose firmware exposes a LampArray-compatible HID descriptor — present today on some models, and possible via future firmware updates on others including the Legion 7 Gen 6 raised in #247 — gets the Dynamic Lighting feature surfaced automatically. Devices without LampArray HID see no change. No new flags, no new resource keys, no UI changes, no third-party dependencies.

This isn't a substitute for a native iCUE-protocol port for #247 (which still requires hardware-side firmware support or hardware-in-hand reverse engineering), but it removes the artificial gate that was suppressing the feature on devices that *do* already support it.

Refs #247 (does not close it; closes the "Dynamic lighting isn't complete yet" subset).

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility update (adding support for new hardware)
- [ ] Documentation update

## Hardware Verification Details
- **Device Series:** Legion 5
- **Exact Model Number:** Legion 5 15AHP11 (machine type 83Q7)
- **BIOS Version:** T2CN33WW
- **Operating System:** Windows 11 Enterprise LTSC, 24H2 (build 26100.8246), x64

## Testing Checklist
- [x] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [x] I have verified this change on physical hardware.
- [ ] I have included a video/screenshot of the change in action (highly preferred for UI changes).
- [x] My code follows the project's style guidelines.

## Additional Notes
Built against current `master` (1d89c867); `dotnet build` clean and the change actually retires one preexisting `CS1998` warning on the now-properly-awaited `IsSupportedAsync` (warning count: 8 → 6).

The branch is split into two commits so the bug fix can be cherry-picked independently if preferred:
- `84e13421` — `Fixed an infinite-recursion in the EnableLampArray property setter`
- `86ab67f4` — `Auto-detect LampArray-compatible devices instead of gating the feature on a debug-only flag`

Reviewer note on hardware verification: this Legion 5 15AHP11 doesn't expose a LampArray HID (so `IsSupportedAsync` returns `false` for me, the page stays hidden — the previous behaviour for normal users without the debug flag). To exercise the new code path I confirmed the diff against `LampArrayController.StartAsync` (line 115), which uses the same `LampArray.GetDeviceSelector()` selector that's now driving the page-level gate. A reviewer with a Legion model that exposes the HID will see the page surface automatically once this lands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a critical issue with the LED array feature toggle that could cause system instability.

* **Improvements**
  * Enhanced hardware detection to properly identify Lamp Array-compatible keyboards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->