### PR TITLE
Fix dwm.exe and explorer.exe being force-killable from the discrete GPU management window

### DIFF
--- a/LenovoLegionToolkit.Lib/Extensions/PhyscialGPUExtensions.cs
+++ b/LenovoLegionToolkit.Lib/Extensions/PhyscialGPUExtensions.cs
@@ -15,20 +15,23 @@ public static class NVAPIExtensions
         "explorer.exe",
     ];
 
+    public static bool IsExcluded(string processName) =>
+        Exclusions.Contains(processName, StringComparer.InvariantCultureIgnoreCase);
+
     public static (List<Process> All, List<Process> Filtered) GetActiveProcesses(PhysicalGPU gpu)
     {
         var allProcesses = new List<Process>();
         var filteredProcesses = new List<Process>();
         var apps = GPUApi.QueryActiveApps(gpu.Handle);
-        
+
         foreach (var app in apps)
         {
             try
             {
                 var process = Process.GetProcessById(app.ProcessId);
                 allProcesses.Add(process);
-                
-                if (!Exclusions.Contains(app.ProcessName, StringComparer.InvariantCultureIgnoreCase))
+
+                if (!IsExcluded(app.ProcessName))
                 {
                     filteredProcesses.Add(process);
                 }

--- a/LenovoLegionToolkit.WPF/Windows/Dashboard/DiscreteGPUManagementWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Dashboard/DiscreteGPUManagementWindow.xaml.cs
@@ -116,12 +116,15 @@ public partial class DiscreteGPUManagementWindow : BaseWindow
 
                 var preference = _gpuController.GetGpuPreference(path).ToString();
 
+                var isProtected = NVAPIExtensions.IsExcluded(Path.GetFileName(path) ?? string.Empty);
+
                 var existing = _apps.FirstOrDefault(a => a.Path.Equals(path, StringComparison.OrdinalIgnoreCase));
                 if (existing != null)
                 {
                     existing.ProcessIds = processIds;
                     existing.IsActive = isActive;
                     existing.Preference = preference;
+                    existing.IsProtected = isProtected;
                 }
                 else
                 {
@@ -134,6 +137,7 @@ public partial class DiscreteGPUManagementWindow : BaseWindow
                         ProcessIds = processIds,
                         Preference = preference,
                         IsPreferenceEnabled = data.hasMultipleGpus,
+                        IsProtected = isProtected,
                         Icon = icon
                     });
                 }
@@ -241,6 +245,9 @@ public partial class DiscreteGPUManagementWindow : BaseWindow
     {
         if (sender is MenuItem menuItem && menuItem.CommandParameter is List<int> pids)
         {
+            if (menuItem.DataContext is DiscreteGPUAppViewModel { IsProtected: true })
+                return;
+
             foreach (var pid in pids)
             {
                 try
@@ -277,7 +284,8 @@ public class DiscreteGPUAppViewModel : INotifyPropertyChanged
             OnPropertyChanged(nameof(CanKill));
         }
     }
-    public bool CanKill => IsActive && ProcessIds.Count > 0;
+    public bool IsProtected { get; set; }
+    public bool CanKill => IsActive && ProcessIds.Count > 0 && !IsProtected;
 
     private bool _isActive;
     public bool IsActive


### PR DESCRIPTION
## Description
Re-targeted from #287 (closed; was opened against `master` by mistake. Every recently merged PR in this repo lands on `dev`, so this one is now correctly based off `dev`).

The Discrete GPU Management window's "Force Kill Process" context menu allows killing any process in the active-on-dGPU list, including `dwm.exe` and `explorer.exe`. Killing `dwm.exe` causes Windows to restart the desktop compositor, and the LLT WPF main window loses visibility on the new compositor session, leaving the app running with no usable UI (the symptom in #286).

`NVAPIExtensions` already maintains an exclusion list (`dwm.exe`, `explorer.exe`) for the GPU-deactivation flow but it isn't applied to the per-app context menu. This PR exposes the existing list as `NVAPIExtensions.IsExcluded(processName)`, sets `IsProtected` on the corresponding view-model entries, and folds it into `CanKill` so the existing `IsEnabled="{Binding CanKill}"` binding greys out the menu item. The click handler also bails if the source view-model is protected (defense-in-depth against any XAML binding race).

`IsProtected` is also written on the `existing != null` refresh branch (so future dynamic exclusion-list changes wouldn't leave stale flags), and the filename lookup is null-guarded for the project's `<Nullable>enable</Nullable>` setting. Both per CodeRabbit nitpicks on the original #287.

No new resource keys, XAML, or localization changes. Set of protected names matches the list already used by `KillGPUProcessesAsync`.

- Fixes #286

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility update (adding support for new hardware)
- [ ] Documentation update

## Hardware Verification Details
- **Device Series:** Legion 5
- **Exact Model Number:** Legion 5 15AHP11 (machine type 83Q7)
- **BIOS Version:** T2CN33WW
- **Operating System:** Windows 11 Enterprise LTSC, 24H2 (build 26100.8246), x64

## Testing Checklist
- [x] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [x] I have verified this change on physical hardware.
- [ ] I have included a video/screenshot of the change in action (highly preferred for UI changes).
- [x] My code follows the project's style guidelines.

## Additional Notes
Built against current `dev` (79d2ca11); `dotnet build` clean (no new warnings, 0 errors).

Note for reviewers: GitHub Actions' "Build" check fails on PRs from forks because the `LLT_CERT_PFX` repository secret isn't passed to fork-PR workflows (this is a GitHub security default, not specific to this PR). The build step `Restore identity package signing key` does `exit 1` when the secret is empty. The actual `dotnet build` step is never reached. Same root cause as the closed #287, it's a fork-CI configuration concern, not a code issue. Happy to leave the bypass-/skip- step gated to maintainer-side runs in a follow-up if useful.