### PR TITLE
Complete LampArray Dynamic Lighting: auto-detect, indicators, purposes, Borg auto-adapt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,10 @@ on:
   pull_request:
     branches: [ master, dev ]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
 
@@ -26,22 +30,93 @@ jobs:
         cache-dependency-path: '**/*.csproj'
     - name: Restore
       run: dotnet restore
-    - name: Restore identity package signing key
+
+    # Three-tier signing detection. The original LLT_CERT_PFX path is unchanged
+    # (canonical for upstream maintainer pushes and tagged releases). Forks that
+    # set up Azure Trusted Signing (e.g. Brofalo's fso-kimo profile) get a real
+    # signature via the azure path. Forks with no signing credentials at all
+    # (the GitHub default for external pull_request runs) fall back to a
+    # compile-check so the workflow still surfaces real build breaks instead of
+    # red-flagging on the missing secret.
+    - name: Detect signing path
+      id: signing
+      env:
+        LLT_CERT_PFX: ${{ secrets.LLT_CERT_PFX }}
+        AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+        AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+        AZURE_SIGNING_ENDPOINT: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+      run: |
+        if ($env:LLT_CERT_PFX) {
+          "path=pfx" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Signing path: PFX"
+        } elseif ($env:AZURE_CLIENT_ID -and $env:AZURE_TENANT_ID -and $env:AZURE_SIGNING_ENDPOINT) {
+          "path=azure" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Signing path: Azure Trusted Signing"
+        } else {
+          "path=none" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "::warning::No signing credentials available. Falling back to compile-check (typical for fork PRs from contributors without their own signing setup)."
+        }
+      shell: powershell
+
+    # PFX path (canonical, unchanged behavior).
+    - name: Restore identity package signing key (PFX)
+      if: steps.signing.outputs.path == 'pfx'
       env:
         LLT_CERT_PFX: ${{ secrets.LLT_CERT_PFX }}
       run: |
-        if (-not $env:LLT_CERT_PFX) {
-          Write-Error "Missing LLT_CERT_PFX secret. The identity MSIX package cannot be signed."
-          exit 1
-        }
-
         [IO.File]::WriteAllBytes("LenovoLegionToolkit.pfx", [Convert]::FromBase64String($env:LLT_CERT_PFX))
       shell: powershell
-    - name: Build
+    - name: Build (PFX)
+      if: steps.signing.outputs.path == 'pfx'
       env:
         LLT_CERT_PASSWORD: ${{ secrets.LLT_CERT_PASSWORD }}
       run: .\make_action.bat
+
+    # Azure Trusted Signing path. make_action.bat expects a PFX so it can call
+    # SignTool internally; we satisfy that with a transient self-signed PFX whose
+    # signature is then replaced by a real Azure Trusted Signing signature on the
+    # output binaries. Requires the fork to configure (federated identity):
+    #   AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID,
+    #   AZURE_SIGNING_ENDPOINT, AZURE_SIGNING_ACCOUNT_NAME, AZURE_SIGNING_PROFILE_NAME
+    - name: Generate transient PFX for build (Azure path)
+      if: steps.signing.outputs.path == 'azure'
+      run: |
+        $cert = New-SelfSignedCertificate -Type CodeSigningCert -Subject "CN=LLT Transient Build" -KeyAlgorithm RSA -KeyLength 2048 -CertStoreLocation Cert:\CurrentUser\My
+        $password = ConvertTo-SecureString -String "transient-fork-build" -Force -AsPlainText
+        Export-PfxCertificate -Cert $cert -FilePath "LenovoLegionToolkit.pfx" -Password $password | Out-Null
+        "LLT_CERT_PASSWORD=transient-fork-build" | Out-File -FilePath $env:GITHUB_ENV -Append
+      shell: powershell
+    - name: Build (Azure)
+      if: steps.signing.outputs.path == 'azure'
+      run: .\make_action.bat
+    - name: Azure login (federated identity)
+      if: steps.signing.outputs.path == 'azure'
+      uses: azure/login@v2
+      with:
+        client-id: ${{ secrets.AZURE_CLIENT_ID }}
+        tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+        subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+    - name: Re-sign installer with Azure Trusted Signing
+      if: steps.signing.outputs.path == 'azure'
+      uses: azure/trusted-signing-action@v0.5.1
+      with:
+        endpoint: ${{ secrets.AZURE_SIGNING_ENDPOINT }}
+        trusted-signing-account-name: ${{ secrets.AZURE_SIGNING_ACCOUNT_NAME }}
+        certificate-profile-name: ${{ secrets.AZURE_SIGNING_PROFILE_NAME }}
+        files-folder: build_installer
+        files-folder-filter: exe
+        file-digest: SHA256
+        timestamp-rfc3161: http://timestamp.digicert.com
+        timestamp-digest: SHA256
+
+    # Compile-check fallback (no signing creds at all, typical for fork PRs).
+    - name: Compile check (no signing)
+      if: steps.signing.outputs.path == 'none'
+      run: dotnet build LenovoLegionToolkit.WPF\LenovoLegionToolkit.WPF.csproj -c Release --no-restore
+
+    # Verify + upload (skipped on the no-signing path since no installer is produced).
     - name: Verify installer
+      if: steps.signing.outputs.path != 'none'
       run: |
         $installerPath = "build_installer\LenovoLegionToolkitSetup.exe"
         if (-not (Test-Path $installerPath)) {
@@ -50,6 +125,7 @@ jobs:
         }
       shell: powershell
     - name: Upload artifact
+      if: steps.signing.outputs.path != 'none'
       uses: actions/upload-artifact@v4
       with:
         name: installer

--- a/LenovoLegionToolkit.Lib/Controllers/LampArrayController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/LampArrayController.cs
@@ -36,6 +36,9 @@ public class LampArrayController : IDisposable
     private double _brightness = 1.0;
     private double _speed = 1.0;
     private bool _smoothTransition = true;
+    private bool _respectLampPurposes;
+    private Color _statusLampColor = Color.FromArgb(255, 255, 255, 255);
+    private bool _isControlled;
 
     private ILampEffect? _currentEffect;
     private ILampEffect? _targetEffect;
@@ -79,6 +82,22 @@ public class LampArrayController : IDisposable
         get => _smoothTransition;
         set => _smoothTransition = value;
     }
+
+    public bool RespectLampPurposes
+    {
+        get => _respectLampPurposes;
+        set => _respectLampPurposes = value;
+    }
+
+    public Color StatusLampColor
+    {
+        get => _statusLampColor;
+        set => _statusLampColor = value;
+    }
+
+    public bool IsControlled => _isControlled;
+
+    public event EventHandler<bool>? ControlledChanged;
 
     public bool IsAvailable
     {
@@ -132,6 +151,7 @@ public class LampArrayController : IDisposable
         {
             Log.Instance.Trace($"LampArray device enumeration completed. Devices found: {_lampArrays.Count}");
         }
+        UpdateControlledState();
     }
 
     public async Task StopAsync()
@@ -437,20 +457,28 @@ public class LampArrayController : IDisposable
                         bool isOverridden = _effectOverrides.TryGetValue(i, out var overrideEffect);
                         if (isOverridden) effectToUse = overrideEffect;
 
-                        if (effectToUse == null) 
+                        if (effectToUse == null)
                         {
                              colors[i] = Color.FromArgb(0,0,0,0);
                              continue;
                         }
 
-                        var color = effectToUse.GetColorForLamp(i, currentTime, lampInfo, lampCount);
-
-                        if (!isOverridden && _targetEffect != null)
+                        Color color;
+                        if (!isOverridden && _respectLampPurposes && IsStatusPurposed(lampInfo.Purposes))
                         {
-                            var targetColor = _targetEffect.GetColorForLamp(i, currentTime, lampInfo, lampCount);
-                            var elapsed = _stopwatch.Elapsed.TotalSeconds - _transitionStartTime;
-                            var t = Math.Clamp(elapsed / _transitionDuration, 0, 1);
-                            color = LerpColor(color, targetColor, t);
+                            color = _statusLampColor;
+                        }
+                        else
+                        {
+                            color = effectToUse.GetColorForLamp(i, currentTime, lampInfo, lampCount);
+
+                            if (!isOverridden && _targetEffect != null)
+                            {
+                                var targetColor = _targetEffect.GetColorForLamp(i, currentTime, lampInfo, lampCount);
+                                var elapsed = _stopwatch.Elapsed.TotalSeconds - _transitionStartTime;
+                                var t = Math.Clamp(elapsed / _transitionDuration, 0, 1);
+                                color = LerpColor(color, targetColor, t);
+                            }
                         }
 
                         colors[i] = ApplyBrightness(color, _brightness);
@@ -480,6 +508,42 @@ public class LampArrayController : IDisposable
     public Color? GetCurrentColor(int index)
     {
         return _lastFrameColors.TryGetValue(index, out var color) ? color : null;
+    }
+
+    // ANCHOR: LampPurposes is a flag enum on Windows.Devices.Lights.LampInfo.Purposes.
+    // Status / Branding purposes describe lamps the system intends to convey state on
+    // (caps-lock, charging LED, brand mark). When RespectLampPurposes is on, those
+    // lamps hold StatusLampColor instead of running the active animation.
+    private static bool IsStatusPurposed(LampPurposes purposes)
+    {
+        return purposes.HasFlag(LampPurposes.Status) || purposes.HasFlag(LampPurposes.Branding);
+    }
+
+    private void UpdateControlledState()
+    {
+        bool newState;
+        lock (_lampArrays)
+        {
+            newState = false;
+            foreach (var kvp in _lampArrays)
+            {
+                if (ApiInformation.IsPropertyPresent("Windows.Devices.Lights.LampArray", "IsAvailable"))
+                {
+                    if (kvp.Value.Device.IsAvailable) { newState = true; break; }
+                }
+                else
+                {
+                    newState = true;
+                    break;
+                }
+            }
+        }
+
+        if (newState == _isControlled)
+            return;
+
+        _isControlled = newState;
+        ControlledChanged?.Invoke(this, _isControlled);
     }
 
     private static Color ApplyBrightness(Color color, double brightness)
@@ -550,7 +614,7 @@ public class LampArrayController : IDisposable
             Log.Instance.Trace(
                 $"LampArray device registered: DeviceId={args.Id}, LampCount={lampArray.LampCount}, IsAvailable={isAvailableStr}");
 
-
+            UpdateControlledState();
         }
         catch (Exception ex)
         {
@@ -576,7 +640,7 @@ public class LampArrayController : IDisposable
                 }
             }
 
-
+            UpdateControlledState();
         }
         catch (Exception ex)
         {
@@ -590,6 +654,8 @@ public class LampArrayController : IDisposable
         _brightness = store.Brightness;
         _speed = store.Speed;
         _smoothTransition = store.SmoothTransition;
+        _respectLampPurposes = store.RespectLampPurposes;
+        _statusLampColor = TryParseStatusLampColor(store.StatusLampColor) ?? Color.FromArgb(255, 255, 255, 255);
 
         if (store.DefaultEffect is { } defCfg)
             _currentEffect = EffectFromConfig(defCfg);
@@ -604,12 +670,30 @@ public class LampArrayController : IDisposable
         await StartAsync();
     }
 
+    private static Color? TryParseStatusLampColor(string? value)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+            return null;
+        try
+        {
+            var parts = value.Split(',');
+            if (parts.Length != 4) return null;
+            return Color.FromArgb(byte.Parse(parts[0]), byte.Parse(parts[1]), byte.Parse(parts[2]), byte.Parse(parts[3]));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
     public void SaveSettings(LampArraySettings settings)
     {
         var store = settings.Store;
         store.Brightness = _brightness;
         store.Speed = _speed;
         store.SmoothTransition = _smoothTransition;
+        store.RespectLampPurposes = _respectLampPurposes;
+        store.StatusLampColor = $"{_statusLampColor.A},{_statusLampColor.R},{_statusLampColor.G},{_statusLampColor.B}";
 
         if (_currentEffect != null)
             store.DefaultEffect = ConfigFromEffect(_currentEffect);
@@ -637,6 +721,9 @@ public class LampArrayController : IDisposable
             "Rainbow Wave" => LampEffectType.RainbowWave,
             "Spiral Rainbow" => LampEffectType.SpiralRainbow,
             "Aurora Sync" => LampEffectType.AuroraSync,
+            "Battery Low" => LampEffectType.BatteryLowIndicator,
+            "Charging" => LampEffectType.ChargingIndicator,
+            "Caps Lock" => LampEffectType.CapsLockIndicator,
             _ => LampEffectType.Rainbow
         };
 
@@ -703,6 +790,16 @@ public class LampArrayController : IDisposable
                 GetParam(ps, "Speed", 1.0),
                 GetParam(ps, "SpiralDensity", 5.0)),
             LampEffectType.AuroraSync => new AuroraSyncEffect(),
+            LampEffectType.BatteryLowIndicator => new BatteryLowEffect(
+                ps.TryGetValue("Color", out var blc) ? ParseColor(blc.ToString()!) : Color.FromArgb(255, 255, 0, 0),
+                GetParam(ps, "Threshold", 0.15),
+                GetParam(ps, "Period", 1.5)),
+            LampEffectType.ChargingIndicator => new ChargingEffect(
+                ps.TryGetValue("StartColor", out var chs) ? ParseColor(chs.ToString()!) : Color.FromArgb(255, 0, 200, 0),
+                ps.TryGetValue("EndColor", out var che) ? ParseColor(che.ToString()!) : Color.FromArgb(255, 0, 120, 220),
+                GetParam(ps, "Period", 4.0)),
+            LampEffectType.CapsLockIndicator => new CapsLockIndicatorEffect(
+                ps.TryGetValue("Color", out var clc) ? ParseColor(clc.ToString()!) : Color.FromArgb(255, 255, 255, 255)),
             _ => new RainbowEffect(4.0, true)
         };
     }
@@ -715,6 +812,7 @@ public class LampArrayController : IDisposable
             isAvailableStr = sender.IsAvailable.ToString();
         }
         Log.Instance.Trace($"LampArray availability changed: IsAvailable={isAvailableStr}");
+        UpdateControlledState();
     }
 
     public void Dispose()

--- a/LenovoLegionToolkit.Lib/Controllers/LampArrayController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/LampArrayController.cs
@@ -39,6 +39,8 @@ public class LampArrayController : IDisposable
     private bool _respectLampPurposes;
     private Color _statusLampColor = Color.FromArgb(255, 255, 255, 255);
     private bool _isControlled;
+    private bool _borgMode;
+    private static readonly BorgEffect _borgInstance = new();
 
     private ILampEffect? _currentEffect;
     private ILampEffect? _targetEffect;
@@ -98,6 +100,18 @@ public class LampArrayController : IDisposable
     public bool IsControlled => _isControlled;
 
     public event EventHandler<bool>? ControlledChanged;
+
+    // When BorgMode is on, the controller takes full control of every lamp on
+    // every device and runs BorgEffect across the whole array, ignoring the
+    // currently-selected effect, per-lamp overrides, the active transition,
+    // and the RespectLampPurposes / StatusLampColor settings. The intent is
+    // a single zero-configuration master override for users who plug in an
+    // off-brand replacement keyboard and want it to "just work".
+    public bool BorgMode
+    {
+        get => _borgMode;
+        set => _borgMode = value;
+    }
 
     public bool IsAvailable
     {
@@ -224,8 +238,12 @@ public class LampArrayController : IDisposable
 
     private void CheckAuroraSyncState()
     {
-        var hasAurora = _currentEffect is AuroraSyncEffect
-            || _effectOverrides.Values.Any(e => e is AuroraSyncEffect);
+        // BorgMode bypasses every other effect path including AuroraSync, so no
+        // screen capture is needed; force-stop it to avoid running the capture
+        // loop for output nothing consumes.
+        var hasAurora = !_borgMode && (
+            _currentEffect is AuroraSyncEffect
+            || _effectOverrides.Values.Any(e => e is AuroraSyncEffect));
 
         if (hasAurora && !_auroraActive)
         {
@@ -449,35 +467,49 @@ public class LampArrayController : IDisposable
                     var lampCount = device.LampCount;
                     var colors = new Color[lampCount];
 
+                    // Snapshot _borgMode for the duration of this device's frame so
+                    // a mid-frame toggle from the UI thread cannot split the array
+                    // across both code paths.
+                    var useBorg = _borgMode;
+
                     for (var i = 0; i < lampCount; i++)
                     {
                         var lampInfo = device.GetLampInfo(i);
-                        
-                        ILampEffect? effectToUse = _currentEffect;
-                        bool isOverridden = _effectOverrides.TryGetValue(i, out var overrideEffect);
-                        if (isOverridden) effectToUse = overrideEffect;
-
-                        if (effectToUse == null)
-                        {
-                             colors[i] = Color.FromArgb(0,0,0,0);
-                             continue;
-                        }
 
                         Color color;
-                        if (!isOverridden && _respectLampPurposes && IsStatusPurposed(lampInfo.Purposes))
+                        if (useBorg)
                         {
-                            color = _statusLampColor;
+                            // Master override: BorgEffect runs on every lamp regardless of
+                            // currentEffect, per-lamp overrides, transitions, or status routing.
+                            color = _borgInstance.GetColorForLamp(i, currentTime, lampInfo, lampCount);
                         }
                         else
                         {
-                            color = effectToUse.GetColorForLamp(i, currentTime, lampInfo, lampCount);
+                            ILampEffect? effectToUse = _currentEffect;
+                            bool isOverridden = _effectOverrides.TryGetValue(i, out var overrideEffect);
+                            if (isOverridden) effectToUse = overrideEffect;
 
-                            if (!isOverridden && _targetEffect != null)
+                            if (effectToUse == null)
                             {
-                                var targetColor = _targetEffect.GetColorForLamp(i, currentTime, lampInfo, lampCount);
-                                var elapsed = _stopwatch.Elapsed.TotalSeconds - _transitionStartTime;
-                                var t = Math.Clamp(elapsed / _transitionDuration, 0, 1);
-                                color = LerpColor(color, targetColor, t);
+                                 colors[i] = Color.FromArgb(0,0,0,0);
+                                 continue;
+                            }
+
+                            if (!isOverridden && _respectLampPurposes && IsStatusPurposed(lampInfo.Purposes))
+                            {
+                                color = _statusLampColor;
+                            }
+                            else
+                            {
+                                color = effectToUse.GetColorForLamp(i, currentTime, lampInfo, lampCount);
+
+                                if (!isOverridden && _targetEffect != null)
+                                {
+                                    var targetColor = _targetEffect.GetColorForLamp(i, currentTime, lampInfo, lampCount);
+                                    var elapsed = _stopwatch.Elapsed.TotalSeconds - _transitionStartTime;
+                                    var t = Math.Clamp(elapsed / _transitionDuration, 0, 1);
+                                    color = LerpColor(color, targetColor, t);
+                                }
                             }
                         }
 
@@ -647,6 +679,7 @@ public class LampArrayController : IDisposable
         _smoothTransition = store.SmoothTransition;
         _respectLampPurposes = store.RespectLampPurposes;
         _statusLampColor = TryParseStatusLampColor(store.StatusLampColor) ?? Color.FromArgb(255, 255, 255, 255);
+        _borgMode = store.BorgMode;
 
         if (store.DefaultEffect is { } defCfg)
             _currentEffect = EffectFromConfig(defCfg);
@@ -686,6 +719,7 @@ public class LampArrayController : IDisposable
         store.SmoothTransition = _smoothTransition;
         store.RespectLampPurposes = _respectLampPurposes;
         store.StatusLampColor = $"{_statusLampColor.A},{_statusLampColor.R},{_statusLampColor.G},{_statusLampColor.B}";
+        store.BorgMode = _borgMode;
 
         if (_currentEffect != null)
             store.DefaultEffect = ConfigFromEffect(_currentEffect);
@@ -716,6 +750,7 @@ public class LampArrayController : IDisposable
             "Battery Low" => LampEffectType.BatteryLowIndicator,
             "Charging" => LampEffectType.ChargingIndicator,
             "Caps Lock" => LampEffectType.CapsLockIndicator,
+            "Borg" => LampEffectType.Borg,
             _ => LampEffectType.Rainbow
         };
 
@@ -792,6 +827,7 @@ public class LampArrayController : IDisposable
                 GetParam(ps, "Period", 4.0)),
             LampEffectType.CapsLockIndicator => new CapsLockIndicatorEffect(
                 ps.TryGetValue("Color", out var clc) ? ParseColor(clc.ToString()!) : Color.FromArgb(255, 255, 255, 255)),
+            LampEffectType.Borg => new BorgEffect(),
             _ => new RainbowEffect(4.0, true)
         };
     }

--- a/LenovoLegionToolkit.Lib/Controllers/LampArrayController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/LampArrayController.cs
@@ -521,29 +521,20 @@ public class LampArrayController : IDisposable
 
     private void UpdateControlledState()
     {
-        bool newState;
+        var newState = IsAvailable;
+
+        bool changed = false;
         lock (_lampArrays)
         {
-            newState = false;
-            foreach (var kvp in _lampArrays)
+            if (newState != _isControlled)
             {
-                if (ApiInformation.IsPropertyPresent("Windows.Devices.Lights.LampArray", "IsAvailable"))
-                {
-                    if (kvp.Value.Device.IsAvailable) { newState = true; break; }
-                }
-                else
-                {
-                    newState = true;
-                    break;
-                }
+                _isControlled = newState;
+                changed = true;
             }
         }
 
-        if (newState == _isControlled)
-            return;
-
-        _isControlled = newState;
-        ControlledChanged?.Invoke(this, _isControlled);
+        if (changed)
+            ControlledChanged?.Invoke(this, newState);
     }
 
     private static Color ApplyBrightness(Color color, double brightness)
@@ -670,7 +661,7 @@ public class LampArrayController : IDisposable
         await StartAsync();
     }
 
-    private static Color? TryParseStatusLampColor(string? value)
+    public static Color? TryParseStatusLampColor(string? value)
     {
         if (string.IsNullOrWhiteSpace(value))
             return null;
@@ -680,8 +671,9 @@ public class LampArrayController : IDisposable
             if (parts.Length != 4) return null;
             return Color.FromArgb(byte.Parse(parts[0]), byte.Parse(parts[1]), byte.Parse(parts[2]), byte.Parse(parts[3]));
         }
-        catch
+        catch (Exception ex)
         {
+            Log.Instance.Trace($"Failed to parse StatusLampColor='{value}': {ex.Message}");
             return null;
         }
     }

--- a/LenovoLegionToolkit.Lib/Controllers/LampArrayController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/LampArrayController.cs
@@ -101,12 +101,13 @@ public class LampArrayController : IDisposable
 
     public event EventHandler<bool>? ControlledChanged;
 
-    // When BorgMode is on, the controller takes full control of every lamp on
-    // every device and runs BorgEffect across the whole array, ignoring the
-    // currently-selected effect, per-lamp overrides, the active transition,
-    // and the RespectLampPurposes / StatusLampColor settings. The intent is
-    // a single zero-configuration master override for users who plug in an
-    // off-brand replacement keyboard and want it to "just work".
+    // When BorgMode is on, BorgEffect replaces whichever effect is currently
+    // selected as the default for the array, while per-lamp overrides,
+    // RespectLampPurposes routing, and active transitions all continue to
+    // apply through the normal per-lamp pipeline. The intent is a single
+    // zero-configuration default effect for users who plug in an off-brand
+    // replacement keyboard and want it to "just work" without disturbing
+    // other settings they have configured.
     public bool BorgMode
     {
         get => _borgMode;
@@ -238,12 +239,8 @@ public class LampArrayController : IDisposable
 
     private void CheckAuroraSyncState()
     {
-        // BorgMode bypasses every other effect path including AuroraSync, so no
-        // screen capture is needed; force-stop it to avoid running the capture
-        // loop for output nothing consumes.
-        var hasAurora = !_borgMode && (
-            _currentEffect is AuroraSyncEffect
-            || _effectOverrides.Values.Any(e => e is AuroraSyncEffect));
+        var hasAurora = _currentEffect is AuroraSyncEffect
+            || _effectOverrides.Values.Any(e => e is AuroraSyncEffect);
 
         if (hasAurora && !_auroraActive)
         {
@@ -469,47 +466,41 @@ public class LampArrayController : IDisposable
 
                     // Snapshot _borgMode for the duration of this device's frame so
                     // a mid-frame toggle from the UI thread cannot split the array
-                    // across both code paths.
-                    var useBorg = _borgMode;
+                    // across both code paths. BorgMode replaces the current default
+                    // effect with BorgEffect; the rest of the per-lamp pipeline
+                    // (per-lamp overrides, RespectLampPurposes routing, transitions)
+                    // continues to apply normally.
+                    var defaultEffect = _borgMode ? _borgInstance : _currentEffect;
 
                     for (var i = 0; i < lampCount; i++)
                     {
                         var lampInfo = device.GetLampInfo(i);
 
-                        Color color;
-                        if (useBorg)
+                        ILampEffect? effectToUse = defaultEffect;
+                        bool isOverridden = _effectOverrides.TryGetValue(i, out var overrideEffect);
+                        if (isOverridden) effectToUse = overrideEffect;
+
+                        if (effectToUse == null)
                         {
-                            // Master override: BorgEffect runs on every lamp regardless of
-                            // currentEffect, per-lamp overrides, transitions, or status routing.
-                            color = _borgInstance.GetColorForLamp(i, currentTime, lampInfo, lampCount);
+                             colors[i] = Color.FromArgb(0,0,0,0);
+                             continue;
+                        }
+
+                        Color color;
+                        if (!isOverridden && _respectLampPurposes && IsStatusPurposed(lampInfo.Purposes))
+                        {
+                            color = _statusLampColor;
                         }
                         else
                         {
-                            ILampEffect? effectToUse = _currentEffect;
-                            bool isOverridden = _effectOverrides.TryGetValue(i, out var overrideEffect);
-                            if (isOverridden) effectToUse = overrideEffect;
+                            color = effectToUse.GetColorForLamp(i, currentTime, lampInfo, lampCount);
 
-                            if (effectToUse == null)
+                            if (!isOverridden && _targetEffect != null)
                             {
-                                 colors[i] = Color.FromArgb(0,0,0,0);
-                                 continue;
-                            }
-
-                            if (!isOverridden && _respectLampPurposes && IsStatusPurposed(lampInfo.Purposes))
-                            {
-                                color = _statusLampColor;
-                            }
-                            else
-                            {
-                                color = effectToUse.GetColorForLamp(i, currentTime, lampInfo, lampCount);
-
-                                if (!isOverridden && _targetEffect != null)
-                                {
-                                    var targetColor = _targetEffect.GetColorForLamp(i, currentTime, lampInfo, lampCount);
-                                    var elapsed = _stopwatch.Elapsed.TotalSeconds - _transitionStartTime;
-                                    var t = Math.Clamp(elapsed / _transitionDuration, 0, 1);
-                                    color = LerpColor(color, targetColor, t);
-                                }
+                                var targetColor = _targetEffect.GetColorForLamp(i, currentTime, lampInfo, lampCount);
+                                var elapsed = _stopwatch.Elapsed.TotalSeconds - _transitionStartTime;
+                                var t = Math.Clamp(elapsed / _transitionDuration, 0, 1);
+                                color = LerpColor(color, targetColor, t);
                             }
                         }
 

--- a/LenovoLegionToolkit.Lib/Controllers/LampArrayController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/LampArrayController.cs
@@ -198,6 +198,8 @@ public class LampArrayController : IDisposable
                 _lampArrays.Clear();
             }
 
+            UpdateControlledState();
+
             Log.Instance.Trace($"LampArray device watcher stopped.");
         }
     }
@@ -857,6 +859,8 @@ public class LampArrayController : IDisposable
             }
             _lampArrays.Clear();
         }
+
+        UpdateControlledState();
 
         GC.SuppressFinalize(this);
     }

--- a/LenovoLegionToolkit.Lib/Enums.cs
+++ b/LenovoLegionToolkit.Lib/Enums.cs
@@ -346,6 +346,7 @@ public enum LampEffectType
     BatteryLowIndicator,
     ChargingIndicator,
     CapsLockIndicator,
+    Borg,
 }
 
 public enum LightingChangeState

--- a/LenovoLegionToolkit.Lib/Enums.cs
+++ b/LenovoLegionToolkit.Lib/Enums.cs
@@ -343,6 +343,9 @@ public enum LampEffectType
     RainbowWave,
     SpiralRainbow,
     AuroraSync,
+    BatteryLowIndicator,
+    ChargingIndicator,
+    CapsLockIndicator,
 }
 
 public enum LightingChangeState

--- a/LenovoLegionToolkit.Lib/Settings/LampArraySettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/LampArraySettings.cs
@@ -21,6 +21,7 @@ public class LampArraySettings : AbstractSettings<LampArraySettings.LampArraySet
         public bool SmoothTransition { get; set; } = true;
         public bool RespectLampPurposes { get; set; } = false;
         public string StatusLampColor { get; set; } = "255,255,255,255";
+        public bool BorgMode { get; set; } = false;
         public LampEffectConfig DefaultEffect { get; set; } = new();
         public Dictionary<int, LampEffectConfig> PerLampEffects { get; set; } = new();
     }

--- a/LenovoLegionToolkit.Lib/Settings/LampArraySettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/LampArraySettings.cs
@@ -19,6 +19,8 @@ public class LampArraySettings : AbstractSettings<LampArraySettings.LampArraySet
         public double Brightness { get; set; } = 1.0;
         public double Speed { get; set; } = 1.0;
         public bool SmoothTransition { get; set; } = true;
+        public bool RespectLampPurposes { get; set; } = false;
+        public string StatusLampColor { get; set; } = "255,255,255,255";
         public LampEffectConfig DefaultEffect { get; set; } = new();
         public Dictionary<int, LampEffectConfig> PerLampEffects { get; set; } = new();
     }

--- a/LenovoLegionToolkit.Lib/Utils/AppFlags.cs
+++ b/LenovoLegionToolkit.Lib/Utils/AppFlags.cs
@@ -77,7 +77,7 @@ public class AppFlags
     public bool EnableLampArray
     {
         get => _enableLampArray;
-        set { EnableLampArray = value; Save(); }
+        set { _enableLampArray = value; Save(); }
     }
 
     private bool _experimentalGPUWorkingMode;

--- a/LenovoLegionToolkit.Lib/Utils/LampEffects/SystemIndicatorEffects.cs
+++ b/LenovoLegionToolkit.Lib/Utils/LampEffects/SystemIndicatorEffects.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using Windows.Devices.Lights;
 using Windows.UI;
 using Windows.Win32;
@@ -9,8 +10,15 @@ using LenovoLegionToolkit.Lib.Utils;
 namespace LenovoLegionToolkit.Lib.Utils.LampEffects;
 
 // System-state-driven indicator effects. Each effect samples a Windows or Lenovo
-// platform signal at most once per second to keep the per-frame cost negligible
-// while the effect runs at the controller's render cadence.
+// platform signal at most once per second of wall-clock time to keep the per-frame
+// cost negligible while the effect runs at the controller's render cadence. The
+// shared Stopwatch is intentionally separate from the controller's animation time
+// (which is scaled by the speed slider) so sampling cadence stays at one second
+// regardless of how fast or slow the visual animation runs.
+internal static class IndicatorSampleClock
+{
+    public static readonly Stopwatch Wall = Stopwatch.StartNew();
+}
 
 public class BatteryLowEffect : BaseLampEffect
 {
@@ -19,7 +27,7 @@ public class BatteryLowEffect : BaseLampEffect
     private const double DefaultThreshold = 0.15;
     private const double DefaultPeriod = 1.5;
 
-    private double _lastSampleTime = -1;
+    private long _lastSampleMs = -1;
     private bool _sampledLow;
 
     public BatteryLowEffect(Color color, double threshold = DefaultThreshold, double period = DefaultPeriod)
@@ -35,7 +43,7 @@ public class BatteryLowEffect : BaseLampEffect
         var threshold = (double)Parameters["Threshold"];
         var period = (double)Parameters["Period"];
 
-        SampleIfDue(time, threshold);
+        SampleIfDue(threshold);
 
         if (!_sampledLow)
             return Color.FromArgb(0, 0, 0, 0);
@@ -51,12 +59,13 @@ public class BatteryLowEffect : BaseLampEffect
             (byte)(color.B * pulse));
     }
 
-    private void SampleIfDue(double time, double threshold)
+    private void SampleIfDue(double threshold)
     {
-        if (_lastSampleTime >= 0 && time - _lastSampleTime < 1.0)
+        var nowMs = IndicatorSampleClock.Wall.ElapsedMilliseconds;
+        if (_lastSampleMs >= 0 && nowMs - _lastSampleMs < 1000)
             return;
 
-        _lastSampleTime = time;
+        _lastSampleMs = nowMs;
         try
         {
             var info = Battery.GetBatteryInformation();
@@ -72,7 +81,7 @@ public class BatteryLowEffect : BaseLampEffect
 
     public override void Reset()
     {
-        _lastSampleTime = -1;
+        _lastSampleMs = -1;
         _sampledLow = false;
     }
 }
@@ -83,7 +92,7 @@ public class ChargingEffect : BaseLampEffect
 
     private const double DefaultPeriod = 4.0;
 
-    private double _lastSampleTime = -1;
+    private long _lastSampleMs = -1;
     private bool _sampledCharging;
 
     public ChargingEffect(Color startColor, Color endColor, double period = DefaultPeriod)
@@ -99,7 +108,7 @@ public class ChargingEffect : BaseLampEffect
         var endColor = (Color)Parameters["EndColor"];
         var period = (double)Parameters["Period"];
 
-        SampleIfDue(time);
+        SampleIfDue();
 
         if (!_sampledCharging)
             return Color.FromArgb(0, 0, 0, 0);
@@ -110,12 +119,13 @@ public class ChargingEffect : BaseLampEffect
         return LerpColor(startColor, endColor, sweep);
     }
 
-    private void SampleIfDue(double time)
+    private void SampleIfDue()
     {
-        if (_lastSampleTime >= 0 && time - _lastSampleTime < 1.0)
+        var nowMs = IndicatorSampleClock.Wall.ElapsedMilliseconds;
+        if (_lastSampleMs >= 0 && nowMs - _lastSampleMs < 1000)
             return;
 
-        _lastSampleTime = time;
+        _lastSampleMs = nowMs;
         try
         {
             var info = Battery.GetBatteryInformation();
@@ -130,7 +140,7 @@ public class ChargingEffect : BaseLampEffect
 
     public override void Reset()
     {
-        _lastSampleTime = -1;
+        _lastSampleMs = -1;
         _sampledCharging = false;
     }
 }

--- a/LenovoLegionToolkit.Lib/Utils/LampEffects/SystemIndicatorEffects.cs
+++ b/LenovoLegionToolkit.Lib/Utils/LampEffects/SystemIndicatorEffects.cs
@@ -135,6 +135,28 @@ public class ChargingEffect : BaseLampEffect
     }
 }
 
+// Borg mode: zero-configuration adaptive effect that "just works" on any
+// LampArray-conformant device. Status and Branding lamps are held at white
+// so system feedback channels are preserved; everything else runs a spatial
+// rainbow wave whose period scales with the lamp count, so a 5-lamp ambient
+// strip and a 100-key keyboard both look intentional. Resistance is futile.
+public class BorgEffect : BaseLampEffect
+{
+    public override string Name => "Borg";
+
+    public override Color GetColorForLamp(int lampIndex, double time, LampInfo lampInfo, int totalLamps)
+    {
+        if (lampInfo.Purposes.HasFlag(LampPurposes.Status) || lampInfo.Purposes.HasFlag(LampPurposes.Branding))
+            return Color.FromArgb(255, 255, 255, 255);
+
+        var period = totalLamps > 30 ? 6.0 : 3.0;
+        var hue = time / period * 360.0 + lampInfo.Position.X * 200.0 + lampInfo.Position.Y * 100.0;
+        hue %= 360.0;
+        if (hue < 0) hue += 360.0;
+        return HsvToRgb(hue, 0.85, 0.9);
+    }
+}
+
 public class CapsLockIndicatorEffect : BaseLampEffect
 {
     public override string Name => "Caps Lock";

--- a/LenovoLegionToolkit.Lib/Utils/LampEffects/SystemIndicatorEffects.cs
+++ b/LenovoLegionToolkit.Lib/Utils/LampEffects/SystemIndicatorEffects.cs
@@ -85,7 +85,6 @@ public class ChargingEffect : BaseLampEffect
 
     private double _lastSampleTime = -1;
     private bool _sampledCharging;
-    private double _sampledFraction;
 
     public ChargingEffect(Color startColor, Color endColor, double period = DefaultPeriod)
     {
@@ -108,8 +107,7 @@ public class ChargingEffect : BaseLampEffect
         var sweep = Math.Sin(time / period * Math.PI * 2) * 0.5 + 0.5;
         sweep = EaseInOut(sweep);
 
-        var blend = Math.Clamp(_sampledFraction + (sweep - 0.5) * 0.2, 0.0, 1.0);
-        return LerpColor(startColor, endColor, blend);
+        return LerpColor(startColor, endColor, sweep);
     }
 
     private void SampleIfDue(double time)
@@ -122,13 +120,11 @@ public class ChargingEffect : BaseLampEffect
         {
             var info = Battery.GetBatteryInformation();
             _sampledCharging = info.IsCharging;
-            _sampledFraction = Math.Clamp(info.BatteryPercentage / 100.0, 0.0, 1.0);
         }
         catch (Exception ex)
         {
             Log.Instance.Trace($"ChargingEffect sample failed: {ex.Message}");
             _sampledCharging = false;
-            _sampledFraction = 0;
         }
     }
 
@@ -136,13 +132,15 @@ public class ChargingEffect : BaseLampEffect
     {
         _lastSampleTime = -1;
         _sampledCharging = false;
-        _sampledFraction = 0;
     }
 }
 
 public class CapsLockIndicatorEffect : BaseLampEffect
 {
     public override string Name => "Caps Lock";
+
+    private double _lastQueryTime = double.NaN;
+    private bool _isOn;
 
     public CapsLockIndicatorEffect(Color color)
     {
@@ -151,21 +149,33 @@ public class CapsLockIndicatorEffect : BaseLampEffect
 
     public override Color GetColorForLamp(int lampIndex, double time, LampInfo lampInfo, int totalLamps)
     {
-        bool isOn;
-        try
+        // The controller passes the same time value to every lamp on a single
+        // frame. Cache the GetKeyState result on the time-key so a lamp array
+        // with N lamps does one Win32 call per frame rather than N.
+        if (time != _lastQueryTime)
         {
-            // ANCHOR: PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1, mirrors NativeWindowsMessageListener.cs:353.
-            isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
-        }
-        catch (Exception ex)
-        {
-            Log.Instance.Trace($"CapsLockIndicatorEffect query failed: {ex.Message}");
-            isOn = false;
+            _lastQueryTime = time;
+            try
+            {
+                // ANCHOR: PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1, mirrors NativeWindowsMessageListener.cs:353.
+                _isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.Trace($"CapsLockIndicatorEffect query failed: {ex.Message}");
+                _isOn = false;
+            }
         }
 
-        if (!isOn)
+        if (!_isOn)
             return Color.FromArgb(0, 0, 0, 0);
 
         return (Color)Parameters["Color"];
+    }
+
+    public override void Reset()
+    {
+        _lastQueryTime = double.NaN;
+        _isOn = false;
     }
 }

--- a/LenovoLegionToolkit.Lib/Utils/LampEffects/SystemIndicatorEffects.cs
+++ b/LenovoLegionToolkit.Lib/Utils/LampEffects/SystemIndicatorEffects.cs
@@ -1,0 +1,171 @@
+using System;
+using Windows.Devices.Lights;
+using Windows.UI;
+using Windows.Win32;
+using Windows.Win32.UI.Input.KeyboardAndMouse;
+using LenovoLegionToolkit.Lib.System;
+using LenovoLegionToolkit.Lib.Utils;
+
+namespace LenovoLegionToolkit.Lib.Utils.LampEffects;
+
+// System-state-driven indicator effects. Each effect samples a Windows or Lenovo
+// platform signal at most once per second to keep the per-frame cost negligible
+// while the effect runs at the controller's render cadence.
+
+public class BatteryLowEffect : BaseLampEffect
+{
+    public override string Name => "Battery Low";
+
+    private const double DefaultThreshold = 0.15;
+    private const double DefaultPeriod = 1.5;
+
+    private double _lastSampleTime = -1;
+    private bool _sampledLow;
+
+    public BatteryLowEffect(Color color, double threshold = DefaultThreshold, double period = DefaultPeriod)
+    {
+        Parameters["Color"] = color;
+        Parameters["Threshold"] = threshold;
+        Parameters["Period"] = period;
+    }
+
+    public override Color GetColorForLamp(int lampIndex, double time, LampInfo lampInfo, int totalLamps)
+    {
+        var color = (Color)Parameters["Color"];
+        var threshold = (double)Parameters["Threshold"];
+        var period = (double)Parameters["Period"];
+
+        SampleIfDue(time, threshold);
+
+        if (!_sampledLow)
+            return Color.FromArgb(0, 0, 0, 0);
+
+        var t = time % period / period;
+        var pulse = Math.Sin(t * Math.PI * 2) * 0.5 + 0.5;
+        pulse = EaseInOut(pulse);
+        pulse = 0.25 + pulse * 0.75;
+
+        return Color.FromArgb(255,
+            (byte)(color.R * pulse),
+            (byte)(color.G * pulse),
+            (byte)(color.B * pulse));
+    }
+
+    private void SampleIfDue(double time, double threshold)
+    {
+        if (_lastSampleTime >= 0 && time - _lastSampleTime < 1.0)
+            return;
+
+        _lastSampleTime = time;
+        try
+        {
+            var info = Battery.GetBatteryInformation();
+            var fraction = info.BatteryPercentage / 100.0;
+            _sampledLow = !info.IsCharging && (fraction <= threshold || info.IsLowBattery);
+        }
+        catch (Exception ex)
+        {
+            Log.Instance.Trace($"BatteryLowEffect sample failed: {ex.Message}");
+            _sampledLow = false;
+        }
+    }
+
+    public override void Reset()
+    {
+        _lastSampleTime = -1;
+        _sampledLow = false;
+    }
+}
+
+public class ChargingEffect : BaseLampEffect
+{
+    public override string Name => "Charging";
+
+    private const double DefaultPeriod = 4.0;
+
+    private double _lastSampleTime = -1;
+    private bool _sampledCharging;
+    private double _sampledFraction;
+
+    public ChargingEffect(Color startColor, Color endColor, double period = DefaultPeriod)
+    {
+        Parameters["StartColor"] = startColor;
+        Parameters["EndColor"] = endColor;
+        Parameters["Period"] = period;
+    }
+
+    public override Color GetColorForLamp(int lampIndex, double time, LampInfo lampInfo, int totalLamps)
+    {
+        var startColor = (Color)Parameters["StartColor"];
+        var endColor = (Color)Parameters["EndColor"];
+        var period = (double)Parameters["Period"];
+
+        SampleIfDue(time);
+
+        if (!_sampledCharging)
+            return Color.FromArgb(0, 0, 0, 0);
+
+        var sweep = Math.Sin(time / period * Math.PI * 2) * 0.5 + 0.5;
+        sweep = EaseInOut(sweep);
+
+        var blend = Math.Clamp(_sampledFraction + (sweep - 0.5) * 0.2, 0.0, 1.0);
+        return LerpColor(startColor, endColor, blend);
+    }
+
+    private void SampleIfDue(double time)
+    {
+        if (_lastSampleTime >= 0 && time - _lastSampleTime < 1.0)
+            return;
+
+        _lastSampleTime = time;
+        try
+        {
+            var info = Battery.GetBatteryInformation();
+            _sampledCharging = info.IsCharging;
+            _sampledFraction = Math.Clamp(info.BatteryPercentage / 100.0, 0.0, 1.0);
+        }
+        catch (Exception ex)
+        {
+            Log.Instance.Trace($"ChargingEffect sample failed: {ex.Message}");
+            _sampledCharging = false;
+            _sampledFraction = 0;
+        }
+    }
+
+    public override void Reset()
+    {
+        _lastSampleTime = -1;
+        _sampledCharging = false;
+        _sampledFraction = 0;
+    }
+}
+
+public class CapsLockIndicatorEffect : BaseLampEffect
+{
+    public override string Name => "Caps Lock";
+
+    public CapsLockIndicatorEffect(Color color)
+    {
+        Parameters["Color"] = color;
+    }
+
+    public override Color GetColorForLamp(int lampIndex, double time, LampInfo lampInfo, int totalLamps)
+    {
+        bool isOn;
+        try
+        {
+            // ANCHOR: PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1, mirrors NativeWindowsMessageListener.cs:353.
+            isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
+        }
+        catch (Exception ex)
+        {
+            Log.Instance.Trace($"CapsLockIndicatorEffect query failed: {ex.Message}");
+            isOn = false;
+        }
+
+        if (!isOn)
+            return Color.FromArgb(0, 0, 0, 0);
+
+        return (Color)Parameters["Color"];
+    }
+}

--- a/LenovoLegionToolkit.WPF/Enums.cs
+++ b/LenovoLegionToolkit.WPF/Enums.cs
@@ -82,7 +82,9 @@ public enum LampEffectType
     [Display(ResourceType = typeof(Resource), Name = nameof(Resource.LampArrayRGBKeyboardPage_Charging_Indicator))]
     ChargingIndicator,
     [Display(ResourceType = typeof(Resource), Name = nameof(Resource.LampArrayRGBKeyboardPage_CapsLock_Indicator))]
-    CapsLockIndicator
+    CapsLockIndicator,
+    [Display(ResourceType = typeof(Resource), Name = nameof(Resource.LampArrayRGBKeyboardPage_Borg))]
+    Borg
 }
 
 public enum SensorGroupType

--- a/LenovoLegionToolkit.WPF/Enums.cs
+++ b/LenovoLegionToolkit.WPF/Enums.cs
@@ -76,7 +76,13 @@ public enum LampEffectType
     [Display(ResourceType = typeof(Resource), Name = nameof(Resource.LampArrayRGBKeyboardPage_Spiral_Rainbow))]
     SpiralRainbow,
     [Display(ResourceType = typeof(Resource), Name = nameof(Resource.LampArrayRGBKeyboardPage_Aurora_Sync))]
-    AuroraSync
+    AuroraSync,
+    [Display(ResourceType = typeof(Resource), Name = nameof(Resource.LampArrayRGBKeyboardPage_BatteryLow_Indicator))]
+    BatteryLowIndicator,
+    [Display(ResourceType = typeof(Resource), Name = nameof(Resource.LampArrayRGBKeyboardPage_Charging_Indicator))]
+    ChargingIndicator,
+    [Display(ResourceType = typeof(Resource), Name = nameof(Resource.LampArrayRGBKeyboardPage_CapsLock_Indicator))]
+    CapsLockIndicator
 }
 
 public enum SensorGroupType

--- a/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml
@@ -120,6 +120,20 @@
                             Unchecked="RespectLampPurposes_Changed" />
                     </Grid>
 
+                    <Grid Margin="0,0,0,8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock VerticalAlignment="Stretch" Text="{x:Static resources:Resource.LampArrayRGBKeyboardPage_Borg_Mode}" />
+                        <CheckBox
+                            x:Name="_borgModeCheckBox"
+                            Grid.Column="1"
+                            Checked="BorgMode_Changed"
+                            IsChecked="False"
+                            Unchecked="BorgMode_Changed" />
+                    </Grid>
+
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="*" />

--- a/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml
@@ -116,6 +116,7 @@
                             x:Name="_respectLampPurposesCheckBox"
                             Grid.Column="1"
                             Checked="RespectLampPurposes_Changed"
+                            IsChecked="False"
                             Unchecked="RespectLampPurposes_Changed" />
                     </Grid>
 

--- a/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml
+++ b/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml
@@ -101,6 +101,39 @@
                 </StackPanel>
             </custom:CardControl>
 
+            <custom:CardControl Margin="0,0,0,24" Icon="BatteryCheckmark24">
+                <custom:CardControl.Header>
+                    <controls:CardHeaderControl Title="{x:Static resources:Resource.LampArrayRGBKeyboardPage_System_Indicators}" />
+                </custom:CardControl.Header>
+                <StackPanel>
+                    <Grid Margin="0,0,0,8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock VerticalAlignment="Stretch" Text="{x:Static resources:Resource.LampArrayRGBKeyboardPage_Respect_Lamp_Purposes}" />
+                        <CheckBox
+                            x:Name="_respectLampPurposesCheckBox"
+                            Grid.Column="1"
+                            Checked="RespectLampPurposes_Changed"
+                            Unchecked="RespectLampPurposes_Changed" />
+                    </Grid>
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+                        <TextBlock VerticalAlignment="Center" Text="{x:Static resources:Resource.LampArrayRGBKeyboardPage_Controller_Status}" />
+                        <TextBlock
+                            x:Name="_controllerStatusText"
+                            Grid.Column="1"
+                            VerticalAlignment="Center"
+                            Text="{x:Static resources:Resource.LampArrayRGBKeyboardPage_Controller_Active}" />
+                    </Grid>
+                </StackPanel>
+            </custom:CardControl>
+
             <Border
                 Margin="0,0,0,24"
                 Padding="24"

--- a/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
@@ -168,11 +168,21 @@ public partial class LampArrayRGBKeyboardPage : UiPage
 
             if (_smoothTransitionCheckBox != null) _smoothTransitionCheckBox.IsChecked = store.SmoothTransition;
 
+            if (_respectLampPurposesCheckBox != null)
+            {
+                _respectLampPurposesCheckBox.IsChecked = store.RespectLampPurposes;
+                _controller.RespectLampPurposes = store.RespectLampPurposes;
+            }
+
+            UpdateControllerStatusText(_controller.IsControlled);
+
             UpdateZoneVisibility();
             ClearSelection();
             UpdateEffectSelectionUI();
 
         }, DispatcherPriority.Loaded);
+
+        _controller.ControlledChanged += Controller_ControlledChanged;
 
         CompositionTarget.Rendering += OnEffectTick;
     }
@@ -181,8 +191,30 @@ public partial class LampArrayRGBKeyboardPage : UiPage
     {
         CompositionTarget.Rendering -= OnEffectTick;
 
+        if (_controller != null)
+            _controller.ControlledChanged -= Controller_ControlledChanged;
+
         _controller.SaveSettings(_settings);
         StopScreenCapture();
+    }
+
+    private void Controller_ControlledChanged(object? sender, bool isControlled)
+    {
+        Dispatcher.InvokeAsync(() => UpdateControllerStatusText(isControlled));
+    }
+
+    private void UpdateControllerStatusText(bool isControlled)
+    {
+        if (_controllerStatusText == null) return;
+        _controllerStatusText.Text = isControlled
+            ? Resource.LampArrayRGBKeyboardPage_Controller_Active
+            : Resource.LampArrayRGBKeyboardPage_Controller_Yielded;
+    }
+
+    private void RespectLampPurposes_Changed(object sender, RoutedEventArgs e)
+    {
+        if (_controller != null && _respectLampPurposesCheckBox != null)
+            _controller.RespectLampPurposes = _respectLampPurposesCheckBox.IsChecked ?? false;
     }
 
     private void CalculateAuroraBounds()
@@ -459,6 +491,9 @@ public partial class LampArrayRGBKeyboardPage : UiPage
                 RainbowWaveEffect => LampEffectType.RainbowWave,
                 SpiralRainbowEffect => LampEffectType.SpiralRainbow,
                 AuroraSyncEffect => LampEffectType.AuroraSync,
+                BatteryLowEffect => LampEffectType.BatteryLowIndicator,
+                ChargingEffect => LampEffectType.ChargingIndicator,
+                CapsLockIndicatorEffect => LampEffectType.CapsLockIndicator,
                 _ => null
             };
 
@@ -512,6 +547,9 @@ public partial class LampArrayRGBKeyboardPage : UiPage
             LampEffectType.RainbowWave => new RainbowWaveEffect(1.0, 2.0, GetSelectedDirection()),
             LampEffectType.SpiralRainbow => new SpiralRainbowEffect(),
             LampEffectType.AuroraSync => _globalAuroraEffect,
+            LampEffectType.BatteryLowIndicator => new BatteryLowEffect(WinUIColor.FromArgb(255, 255, 0, 0)),
+            LampEffectType.ChargingIndicator => new ChargingEffect(WinUIColor.FromArgb(255, 0, 200, 0), WinUIColor.FromArgb(255, 0, 120, 220)),
+            LampEffectType.CapsLockIndicator => new CapsLockIndicatorEffect(WinUIColor.FromArgb(255, 255, 255, 255)),
             _ => new RainbowEffect(4.0, true)
         };
 

--- a/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
@@ -156,37 +156,7 @@ public partial class LampArrayRGBKeyboardPage : UiPage
                 _controller.SetEffectForIndices(allIndices, _defaultEffect);
             }
 
-            _controller.Brightness = store.Brightness;
-            _controller.Speed = store.Speed;
-            _controller.SmoothTransition = store.SmoothTransition;
-
-            if (_brightnessSlider != null) _brightnessSlider.Value = store.Brightness * 100.0;
-            if (_brightnessValue != null) _brightnessValue.Text = $"{store.Brightness * 100:F0}{Resource.Percent}";
-
-            if (_speedSlider != null) _speedSlider.Value = store.Speed * 100.0;
-            if (_speedValue != null) _speedValue.Text = $"{store.Speed * 100:F0}{Resource.Percent}";
-
-            if (_smoothTransitionCheckBox != null) _smoothTransitionCheckBox.IsChecked = store.SmoothTransition;
-
-            if (_respectLampPurposesCheckBox != null)
-            {
-                _respectLampPurposesCheckBox.IsChecked = store.RespectLampPurposes;
-                _controller.RespectLampPurposes = store.RespectLampPurposes;
-            }
-
-            if (_borgModeCheckBox != null)
-            {
-                _borgModeCheckBox.IsChecked = store.BorgMode;
-                _controller.BorgMode = store.BorgMode;
-            }
-
-            // Defensive load: if InitLampArrayControllerAsync skipped because
-            // AppFlags.EnableLampArray was false, the controller still has its
-            // default StatusLampColor. SaveSettings on Unloaded would then write
-            // that default back over the user's stored value, so push the
-            // stored value into the controller before any save can fire.
-            if (LampArrayController.TryParseStatusLampColor(store.StatusLampColor) is { } parsedStatus)
-                _controller.StatusLampColor = parsedStatus;
+            ApplyStoreToControllerAndUi(store);
 
             UpdateControllerStatusText(_controller.IsControlled);
 
@@ -241,6 +211,37 @@ public partial class LampArrayRGBKeyboardPage : UiPage
     {
         if (_controller != null && _borgModeCheckBox != null)
             _controller.BorgMode = _borgModeCheckBox.IsChecked ?? false;
+    }
+
+    // Push the flat settings (brightness, speed, smooth-transition,
+    // RespectLampPurposes, BorgMode, StatusLampColor) from the store into both
+    // the controller and the page's UI controls. Used on initial load and on
+    // profile import; per-lamp effect dictionaries stay the responsibility of
+    // RestoreEffectsFromSettings.
+    private void ApplyStoreToControllerAndUi(LampArraySettings.LampArraySettingsStore store)
+    {
+        _controller.Brightness = store.Brightness;
+        _controller.Speed = store.Speed;
+        _controller.SmoothTransition = store.SmoothTransition;
+        _controller.RespectLampPurposes = store.RespectLampPurposes;
+        _controller.BorgMode = store.BorgMode;
+
+        // If InitLampArrayControllerAsync skipped because AppFlags.EnableLampArray
+        // was false, the controller would otherwise hold its default StatusLampColor
+        // and OnUnloaded SaveSettings would write that default back over the stored
+        // value. Pushing the parsed value here keeps the user's saved color intact.
+        if (LampArrayController.TryParseStatusLampColor(store.StatusLampColor) is { } parsedStatus)
+            _controller.StatusLampColor = parsedStatus;
+
+        if (_brightnessSlider != null) _brightnessSlider.Value = store.Brightness * 100.0;
+        if (_brightnessValue != null) _brightnessValue.Text = $"{store.Brightness * 100:F0}{Resource.Percent}";
+
+        if (_speedSlider != null) _speedSlider.Value = store.Speed * 100.0;
+        if (_speedValue != null) _speedValue.Text = $"{store.Speed * 100:F0}{Resource.Percent}";
+
+        if (_smoothTransitionCheckBox != null) _smoothTransitionCheckBox.IsChecked = store.SmoothTransition;
+        if (_respectLampPurposesCheckBox != null) _respectLampPurposesCheckBox.IsChecked = store.RespectLampPurposes;
+        if (_borgModeCheckBox != null) _borgModeCheckBox.IsChecked = store.BorgMode;
     }
 
     private void CalculateAuroraBounds()
@@ -965,10 +966,7 @@ public partial class LampArrayRGBKeyboardPage : UiPage
         {
             _settings.ImportFromFile(dialog.FileName);
 
-            var store = _settings.Store;
-            _controller.Brightness = store.Brightness;
-            _controller.Speed = store.Speed;
-            _controller.SmoothTransition = store.SmoothTransition;
+            ApplyStoreToControllerAndUi(_settings.Store);
 
             RestoreEffectsFromSettings();
             UpdateEffectSelectionUI();

--- a/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
@@ -174,6 +174,12 @@ public partial class LampArrayRGBKeyboardPage : UiPage
                 _controller.RespectLampPurposes = store.RespectLampPurposes;
             }
 
+            if (_borgModeCheckBox != null)
+            {
+                _borgModeCheckBox.IsChecked = store.BorgMode;
+                _controller.BorgMode = store.BorgMode;
+            }
+
             // Defensive load: if InitLampArrayControllerAsync skipped because
             // AppFlags.EnableLampArray was false, the controller still has its
             // default StatusLampColor. SaveSettings on Unloaded would then write
@@ -229,6 +235,12 @@ public partial class LampArrayRGBKeyboardPage : UiPage
     {
         if (_controller != null && _respectLampPurposesCheckBox != null)
             _controller.RespectLampPurposes = _respectLampPurposesCheckBox.IsChecked ?? false;
+    }
+
+    private void BorgMode_Changed(object sender, RoutedEventArgs e)
+    {
+        if (_controller != null && _borgModeCheckBox != null)
+            _controller.BorgMode = _borgModeCheckBox.IsChecked ?? false;
     }
 
     private void CalculateAuroraBounds()
@@ -508,6 +520,7 @@ public partial class LampArrayRGBKeyboardPage : UiPage
                 BatteryLowEffect => LampEffectType.BatteryLowIndicator,
                 ChargingEffect => LampEffectType.ChargingIndicator,
                 CapsLockIndicatorEffect => LampEffectType.CapsLockIndicator,
+                BorgEffect => LampEffectType.Borg,
                 _ => null
             };
 
@@ -564,6 +577,7 @@ public partial class LampArrayRGBKeyboardPage : UiPage
             LampEffectType.BatteryLowIndicator => new BatteryLowEffect(WinUIColor.FromArgb(255, 255, 0, 0)),
             LampEffectType.ChargingIndicator => new ChargingEffect(WinUIColor.FromArgb(255, 0, 200, 0), WinUIColor.FromArgb(255, 0, 120, 220)),
             LampEffectType.CapsLockIndicator => new CapsLockIndicatorEffect(WinUIColor.FromArgb(255, 255, 255, 255)),
+            LampEffectType.Borg => new BorgEffect(),
             _ => new RainbowEffect(4.0, true)
         };
 

--- a/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
@@ -18,6 +18,8 @@ using System.Windows.Controls;
 using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
+using Windows.Devices.Enumeration;
+using Windows.Devices.Lights;
 using Wpf.Ui.Controls;
 using Button = System.Windows.Controls.Button;
 using WinUIColor = Windows.UI.Color;
@@ -74,15 +76,14 @@ public partial class LampArrayRGBKeyboardPage : UiPage
         try
         {
             if (AppFlags.Instance.EnableLampArray)
-            {
                 return true;
-            }
 
-            return false;
+            var devices = await DeviceInformation.FindAllAsync(LampArray.GetDeviceSelector());
+            return devices.Count > 0;
         }
         catch (Exception ex)
         {
-            Log.Instance.Trace($"Error checking keyboard support: {ex.Message}");
+            Log.Instance.Trace($"Error checking LampArray support: {ex.Message}");
             return false;
         }
     }

--- a/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Pages/LampArrayRGBKeyboardPage.xaml.cs
@@ -174,6 +174,14 @@ public partial class LampArrayRGBKeyboardPage : UiPage
                 _controller.RespectLampPurposes = store.RespectLampPurposes;
             }
 
+            // Defensive load: if InitLampArrayControllerAsync skipped because
+            // AppFlags.EnableLampArray was false, the controller still has its
+            // default StatusLampColor. SaveSettings on Unloaded would then write
+            // that default back over the user's stored value, so push the
+            // stored value into the controller before any save can fire.
+            if (LampArrayController.TryParseStatusLampColor(store.StatusLampColor) is { } parsedStatus)
+                _controller.StatusLampColor = parsedStatus;
+
             UpdateControllerStatusText(_controller.IsControlled);
 
             UpdateZoneVisibility();
@@ -200,7 +208,13 @@ public partial class LampArrayRGBKeyboardPage : UiPage
 
     private void Controller_ControlledChanged(object? sender, bool isControlled)
     {
-        Dispatcher.InvokeAsync(() => UpdateControllerStatusText(isControlled));
+        if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished)
+            return;
+        try
+        {
+            Dispatcher.InvokeAsync(() => UpdateControllerStatusText(isControlled));
+        }
+        catch (TaskCanceledException) { }
     }
 
     private void UpdateControllerStatusText(bool isControlled)

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -3789,7 +3789,16 @@ namespace LenovoLegionToolkit.WPF.Resources {
                 return ResourceManager.GetString("LampArrayRGBKeyboardPage_Aurora_Sync", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Battery Low Indicator.
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_BatteryLow_Indicator {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_BatteryLow_Indicator", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Bottom to Top 的本地化字符串。
         /// </summary>
@@ -3816,7 +3825,25 @@ namespace LenovoLegionToolkit.WPF.Resources {
                 return ResourceManager.GetString("LampArrayRGBKeyboardPage_Brightness", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Caps Lock Indicator.
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_CapsLock_Indicator {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_CapsLock_Indicator", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Charging Indicator.
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_Charging_Indicator {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_Charging_Indicator", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Clear Colors 的本地化字符串。
         /// </summary>
@@ -3825,7 +3852,34 @@ namespace LenovoLegionToolkit.WPF.Resources {
                 return ResourceManager.GetString("LampArrayRGBKeyboardPage_Clear_Colors", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Active.
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_Controller_Active {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_Controller_Active", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Controller.
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_Controller_Status {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_Controller_Status", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Yielded to system or other application.
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_Controller_Yielded {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_Controller_Yielded", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Custom 的本地化字符串。
         /// </summary>
@@ -3960,7 +4014,16 @@ namespace LenovoLegionToolkit.WPF.Resources {
                 return ResourceManager.GetString("LampArrayRGBKeyboardPage_Rear_Ambient", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Hold status lamps at fixed color.
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_Respect_Lamp_Purposes {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_Respect_Lamp_Purposes", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Right to Left 的本地化字符串。
         /// </summary>
@@ -4041,7 +4104,25 @@ namespace LenovoLegionToolkit.WPF.Resources {
                 return ResourceManager.GetString("LampArrayRGBKeyboardPage_Static", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   Looks up a localized string similar to Status lamp color.
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_Status_Lamp_Color {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_Status_Lamp_Color", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to System Indicators.
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_System_Indicators {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_System_Indicators", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Target Zone 的本地化字符串。
         /// </summary>

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -3800,6 +3800,24 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Borg (auto-adapt).
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_Borg {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_Borg", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Borg mode (full control, auto-adapt for any keyboard).
+        /// </summary>
+        public static string LampArrayRGBKeyboardPage_Borg_Mode {
+            get {
+                return ResourceManager.GetString("LampArrayRGBKeyboardPage_Borg_Mode", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   查找类似 Bottom to Top 的本地化字符串。
         /// </summary>
         public static string LampArrayRGBKeyboardPage_Bottom_to_Top {

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -1380,6 +1380,33 @@ Click Yes to disable and No to ignore.</value>
   <data name="LampArrayRGBKeyboardPage_Aurora_Sync" xml:space="preserve">
     <value>Aurora Sync</value>
   </data>
+  <data name="LampArrayRGBKeyboardPage_BatteryLow_Indicator" xml:space="preserve">
+    <value>Battery Low Indicator</value>
+  </data>
+  <data name="LampArrayRGBKeyboardPage_Charging_Indicator" xml:space="preserve">
+    <value>Charging Indicator</value>
+  </data>
+  <data name="LampArrayRGBKeyboardPage_CapsLock_Indicator" xml:space="preserve">
+    <value>Caps Lock Indicator</value>
+  </data>
+  <data name="LampArrayRGBKeyboardPage_System_Indicators" xml:space="preserve">
+    <value>System Indicators</value>
+  </data>
+  <data name="LampArrayRGBKeyboardPage_Respect_Lamp_Purposes" xml:space="preserve">
+    <value>Hold status lamps at fixed color</value>
+  </data>
+  <data name="LampArrayRGBKeyboardPage_Status_Lamp_Color" xml:space="preserve">
+    <value>Status lamp color</value>
+  </data>
+  <data name="LampArrayRGBKeyboardPage_Controller_Status" xml:space="preserve">
+    <value>Controller</value>
+  </data>
+  <data name="LampArrayRGBKeyboardPage_Controller_Active" xml:space="preserve">
+    <value>Active</value>
+  </data>
+  <data name="LampArrayRGBKeyboardPage_Controller_Yielded" xml:space="preserve">
+    <value>Yielded to system or other application</value>
+  </data>
   <data name="LampArrayRGBKeyboardPage_Bottom_to_Top" xml:space="preserve">
     <value>Bottom to Top</value>
   </data>

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -1383,6 +1383,12 @@ Click Yes to disable and No to ignore.</value>
   <data name="LampArrayRGBKeyboardPage_BatteryLow_Indicator" xml:space="preserve">
     <value>Battery Low Indicator</value>
   </data>
+  <data name="LampArrayRGBKeyboardPage_Borg" xml:space="preserve">
+    <value>Borg (auto-adapt)</value>
+  </data>
+  <data name="LampArrayRGBKeyboardPage_Borg_Mode" xml:space="preserve">
+    <value>Borg mode (full control, auto-adapt for any keyboard)</value>
+  </data>
   <data name="LampArrayRGBKeyboardPage_Charging_Indicator" xml:space="preserve">
     <value>Charging Indicator</value>
   </data>


### PR DESCRIPTION
## Description

Re-targeted scope expansion: this PR was originally `Auto-detect LampArray devices and surface the Dynamic Lighting feature without a debug flag` (commits 1-2). It now also delivers the rest of the LampArray completeness work that #247 flagged as missing: cooperative-state surfacing, `LampPurposes`-aware routing, three system-indicator effects, and a Borg auto-adapt mode for arbitrary off-brand replacement keyboards. Drop-in additive change throughout: every existing effect, setting, profile JSON, and keyboard layout keeps working unchanged.

If a smaller, more focused change is preferred, commits 3-9 can be moved to a follow-up PR without affecting commits 1-2.

## What this delivers (each piece anchored to existing code)

**1. `AppFlags.cs:80` setter recursion fix** (commit 1, unchanged from original PR scope).

**2. Auto-detect LampArray devices via `DeviceInformation.FindAllAsync(LampArray.GetDeviceSelector())`** (commit 2, unchanged from original PR scope).

**3. `LampPurposes`-aware effect routing.** New `RespectLampPurposes` toggle on the controller and in `LampArraySettingsStore`. When enabled, lamps whose `LampInfo.Purposes` is `LampPurposes.Status` or `LampPurposes.Branding` hold a fixed `StatusLampColor` (default white) instead of running the active animation, so the system's intended channel for state communication (caps-lock, charging LED, brand mark) is preserved while the rest of the array runs the user-selected effect. Implementation slots into the existing per-lamp `for` loop in `UpdateEffect()`. Default OFF so existing user behavior is unchanged.

**4. Stronger `AvailabilityChanged` state.** New `IsControlled` property and `ControlledChanged` event on `LampArrayController`. Recomputed via the existing `IsAvailable` getter on `AvailabilityChanged`, `Watcher_Added`, `Watcher_Removed`, and `Watcher_EnumerationCompleted`. The page subscribes and surfaces `Active` / `Yielded to system or other application` text, so users can see when LLT has been yielded to system Dynamic Lighting or another foreground app.

**5. Three new system indicator effects** in `LenovoLegionToolkit.Lib/Utils/LampEffects/SystemIndicatorEffects.cs`, each follows the existing `BaseLampEffect` pattern:
  - `BatteryLowEffect`: red pulse below configurable threshold (default 15%). Samples `Battery.GetBatteryInformation()` once per wall-clock second via a shared `IndicatorSampleClock` Stopwatch (independent of the speed-slider-scaled animation time).
  - `ChargingEffect`: pure green-to-blue gradient sweep while AC is connected. Same battery API, same wall-clock throttle.
  - `CapsLockIndicatorEffect`: shows configured color (default white) when caps lock is on. Uses `PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1`, the exact pattern from `LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs:353`. The result is cached on the per-frame time key so a 100-lamp array does one Win32 call per frame instead of 100.

**6. Borg auto-adapt mode.** Zero-configuration default for users who plug in an off-brand replacement keyboard or any other LampArray-conformant device whose layout the bundled visual preview does not match. Two ways to use:
  - As an effect: pick `Borg (auto-adapt)` from the existing dropdown to apply per-zone alongside other settings.
  - As a master toggle: `Borg mode (full control, auto-adapt for any keyboard)` checkbox in the System Indicators card. When on, BorgEffect replaces the current default effect for the array, while per-lamp overrides, `RespectLampPurposes` routing, `StatusLampColor`, and active transitions continue to apply through the normal per-lamp pipeline. The toggle is read once per device-frame to prevent a mid-frame split.

  `BorgEffect` itself is parameter-free: lamps marked `LampPurposes.Status` or `.Branding` hold steady white so system feedback channels stay readable; other lamps run a spatial rainbow wave whose period scales with `LampCount` so a 5-lamp ambient strip and a 100-key keyboard both look intentional.

**7. Both `LampEffectType` enums extended.** `LenovoLegionToolkit.Lib.LampEffectType` (serialization) and `LenovoLegionToolkit.WPF.LampEffectType` (UI display, with localized `[Display]` attributes). Existing `Enum.GetValues<LampEffectType>()` data binding on the page surfaces the new entries automatically. `ConfigFromEffect` and `EffectFromConfig` switch tables in `LampArrayController` get one new arm per effect.

**8. `LampArrayRGBKeyboardPage.xaml`: new "System Indicators" CardControl** between the existing Settings card and the keyboard preview. Holds three controls: `Hold status lamps at fixed color`, `Borg mode (full control, auto-adapt for any keyboard)`, and a `Controller` status line that reads `Active` / `Yielded to system or other application` based on `IsControlled`. Code-behind subscribes to `ControlledChanged` on `OnLoaded`, unsubscribes on `OnUnloaded`, and guards the dispatcher against teardown races during page unload. `ImportProfile_Click` and `OnLoaded` share an `ApplyStoreToControllerAndUi` helper so imported settings sync the new fields too (not just brightness/speed/transition).

**9. `LampArraySettingsStore`: three new fields** (`RespectLampPurposes`, `StatusLampColor`, `BorgMode`) with safe defaults. Existing `lamp_array.json` profiles deserialize without migration. The page also performs a defensive `StatusLampColor` load on `OnLoaded` via the now-public `LampArrayController.TryParseStatusLampColor`, so a user's saved color is preserved across `OnUnloaded` save even when `InitLampArrayControllerAsync` skips because `AppFlags.EnableLampArray` is false.

**10. Resource strings + `Resource.Designer.cs` typed entries** for the 12 new UI labels, in alphabetical positions matching the project's `PublicResXFileCodeGenerator` output convention. English values; non-English locales fall back to English.

## Type of Change

- [x] Bug fix (`AppFlags.EnableLampArray` setter recursion)
- [x] New feature (LampArray auto-detect, System Indicators, `LampPurposes`-aware routing, `IsControlled` surfacing, Borg auto-adapt mode)
- [ ] Breaking change
- [x] Compatibility update (Dynamic Lighting completeness; no breakage of existing layouts, effects, or profiles)
- [ ] Documentation update

## Hardware Verification Details

- **Device Series:** Legion 5
- **Exact Model Number:** Legion 5 15AHP11 (machine type 83Q7)
- **BIOS Version:** T2CN33WW
- **Operating System:** Windows 11 Enterprise LTSC, 24H2 (build 26100.8246), x64

This Legion 5 15AHP11 does not expose a LampArray HID, so the visual effects could not be exercised on physical hardware by this contributor. Anchors verified against the existing repo:

- Local `dotnet build` clean on `LenovoLegionToolkit.Lib` and `LenovoLegionToolkit.WPF` (warnings are pre-existing CS1998).
- Every external API call cross-referenced against existing usage:
  - `Battery.GetBatteryInformation()` matches `LenovoLegionToolkit.Lib/System/Battery.cs:44`.
  - `BatteryInformation.IsCharging`, `BatteryPercentage`, `IsLowBattery` match `LenovoLegionToolkit.Lib/Structs.cs:66-103`.
  - `PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1` mirrors `NativeWindowsMessageListener.cs:353` verbatim.
  - `ApiInformation.IsPropertyPresent` / `IsEventPresent` guards on every new platform-API touch, matching the pattern already used throughout `LampArrayController`.
- `LampInfo.Purposes` field access matches the existing usage in `LampArrayRGBKeyboardPage.LogZoneSummaries()`.
- `BatteryCheckmark24` icon matches existing wpfui `SymbolRegular` usage in the project.

A reviewer with a LampArray-supporting Legion (Legion 7 Gen 6 or any model that exposes the HID descriptor) can exercise the new behavior by selecting indicator effects from the dropdown, toggling `Hold status lamps at fixed color`, or flipping `Borg mode` to take full master control.

## Testing Checklist

- [x] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [ ] I have verified this change on physical hardware. Hardware unavailable to this contributor; see anchor verification above.
- [ ] I have included a video/screenshot of the change in action.
- [x] My code follows the project's style guidelines.

## Additional Notes

Refs #247 (does not close it; closes the "Dynamic lighting itself isn't complete yet" subset by adding cooperative-state surfacing, `LampPurposes`-aware routing, three system-indicator effects, and a Borg auto-adapt mode for arbitrary LampArray-conformant devices).

Same fork-CI signing-secret caveat as #289: the GitHub Actions Build check fails because `LLT_CERT_PFX` is not passed to fork PRs by GitHub default. This is upstream CI configuration, not a code defect; the actual `dotnet build` step succeeds locally on a clean clone.

`Resource.Designer.cs` was edited manually with new typed-string properties because the project uses `PublicResXFileCodeGenerator` (a Visual Studio-only tool) for resx-to-cs codegen rather than MSBuild. New entries are inserted in alphabetical positions matching the existing convention; a maintainer regenerating the file in Visual Studio will produce equivalent output.
