### PR TITLE
Sync smart key cycle index with automation-triggered pipeline runs (#231)

### DIFF
--- a/LenovoLegionToolkit.Lib.Automation/AutomationProcessor.cs
+++ b/LenovoLegionToolkit.Lib.Automation/AutomationProcessor.cs
@@ -38,6 +38,13 @@ public class AutomationProcessor(
 
     public event EventHandler<List<AutomationPipeline>>? PipelinesChanged;
 
+    // Fires after a pipeline finishes successfully on the listener-triggered
+    // path (RunAsync). Lets subscribers react to pipelines that ran because of
+    // an automation event rather than a user-initiated invocation. Not raised
+    // from RunNowAsync, which is reserved for explicit user actions (Smart Key,
+    // tray menu, CLI, "Run Now" button) that callers usually handle directly.
+    public event EventHandler<AutomationPipeline>? PipelineRan;
+
     #region Initialization / pipeline reloading
 
     public async Task InitializeAsync()
@@ -213,6 +220,8 @@ public class AutomationProcessor(
 
                 var otherPipelines = pipelines.Where(p => p.Id != pipeline.Id).ToList();
                 await pipeline.RunAsync(otherPipelines, ct).ConfigureAwait(false);
+
+                PipelineRan?.Invoke(this, pipeline);
 
                 Log.Instance.Trace($"Pipeline completed successfully. [name={pipeline.Name}, trigger={pipeline.Trigger}]");
             }

--- a/LenovoLegionToolkit.WPF/Utils/SmartKeyHelper.cs
+++ b/LenovoLegionToolkit.WPF/Utils/SmartKeyHelper.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using LenovoLegionToolkit.Lib;
 using LenovoLegionToolkit.Lib.Automation;
+using LenovoLegionToolkit.Lib.Automation.Pipeline;
 using LenovoLegionToolkit.Lib.Extensions;
 using LenovoLegionToolkit.Lib.Listeners;
 using LenovoLegionToolkit.Lib.Messaging;
@@ -35,6 +36,54 @@ internal class SmartKeyHelper
     private SmartKeyHelper()
     {
         _specialKeyListener.Changed += SpecialKeyListener_Changed;
+        _automationProcessor.PipelineRan += AutomationProcessor_PipelineRan;
+    }
+
+    // Keeps the smart-key cycle index in sync when a different code path runs
+    // a pipeline that happens to be in the cycle list. Without this, an
+    // automation that runs the same quick action the smart key is about to run
+    // would not advance the cycle, so the next smart-key press would repeat
+    // that quick action. Fires only on the listener-triggered automation path
+    // (see PipelineRan in AutomationProcessor); explicit RunNowAsync paths are
+    // handled by their own callers, so the smart key's own ProcessSpecialKey
+    // continues to advance via its existing logic.
+    private void AutomationProcessor_PipelineRan(object? sender, AutomationPipeline pipeline)
+    {
+        try
+        {
+            var changed = false;
+
+            var single = _settings.Store.SmartKeySinglePressActionList;
+            if (single.Count > 1)
+            {
+                var index = single.IndexOf(pipeline.Id);
+                if (index >= 0)
+                {
+                    var nextIndex = (index + 1) % single.Count;
+                    _settings.Store.SmartKeySinglePressActionId = single[nextIndex];
+                    changed = true;
+                }
+            }
+
+            var doublePress = _settings.Store.SmartKeyDoublePressActionList;
+            if (doublePress.Count > 1)
+            {
+                var index = doublePress.IndexOf(pipeline.Id);
+                if (index >= 0)
+                {
+                    var nextIndex = (index + 1) % doublePress.Count;
+                    _settings.Store.SmartKeyDoublePressActionId = doublePress[nextIndex];
+                    changed = true;
+                }
+            }
+
+            if (changed)
+                _settings.SynchronizeStore();
+        }
+        catch (Exception ex)
+        {
+            Log.Instance.Trace($"Failed to sync smart key cycle index after pipeline run.", ex);
+        }
     }
 
     private async void SpecialKeyListener_Changed(object? sender, SpecialKeyListener.ChangedEventArgs e)


### PR DESCRIPTION
# Pull Request

## Description
When an automation pipeline runs because of an event (e.g. a game starts and triggers a pipeline that runs Quick Action 2), the smart key cycle index now advances past that quick action, so the next smart key press produces the next action in the cycle instead of repeating the one the automation just ran.

- Fixes #231

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility update (adding support for new hardware)
- [ ] Documentation update

## Hardware Verification Details
This change does not interact with BIOS, WMI, ACPI, or any hardware-dependent surface. It only adds an event on `AutomationProcessor` and an in-memory subscription in `SmartKeyHelper` that mutates `ApplicationSettings.Store` and persists via the existing `SynchronizeStore` path. Behavior is identical on every Legion model that already supports the smart key + automation features.

- **Device Series:** Legion 5
- **Exact Model Number:** Legion 5 15AHP11 (machine type 83Q7)
- **BIOS Version:** T2CN33WW (released 2025-12-29)
- **Operating System:** Windows 11 Enterprise LTSC, build 26100, x64

## Testing Checklist
- [ ] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [ ] I have verified this change on physical hardware.
- [ ] I have included a video/screenshot of the change in action (highly preferred for UI changes).
- [x] My code follows the project's style guidelines.

The change builds cleanly on the Legion 5 15AHP11 above (`dotnet build LenovoLegionToolkit.WPF -c Release` clean, only pre-existing CS1998 warnings on files this PR does not touch). Functional verification of the smart-key + automation interaction was not exercised by this contributor; testers with a working Legion smart key plus a game-detection automation setup are welcome to validate the reproduction steps below.

## Additional Notes

### Implementation
- **`AutomationProcessor`**: Added a `PipelineRan` event. It fires after a pipeline finishes successfully on the listener-triggered path (`RunAsync(automationEvent)`). It is not raised from `RunNowAsync`, which is reserved for explicit user-initiated invocations (smart key, tray menu, CLI quick action, "Run Now" button) where the caller already knows what ran and can update its own state directly.
- **`SmartKeyHelper`**: Subscribes to `PipelineRan`. When the event fires, the handler checks both `SmartKeySinglePressActionList` and `SmartKeyDoublePressActionList` for the run pipeline's `Id`; if found, the corresponding `SmartKey*PressActionId` is advanced to the next entry in modular fashion and the settings store is synchronized. Lists with fewer than two entries are skipped because there is nothing to cycle. Smart-key-triggered runs are unaffected because they go through `RunNowAsync`, which does not raise the event, so the existing in-place advance in `ProcessSpecialKey` continues to handle them and there is no double-advance.

### Behavior matrix

| Trigger | Pipeline in cycle list | Cycle index advances |
|---|---|---|
| Smart key press | yes | yes (existing logic in `ProcessSpecialKey`) |
| Automation event (game detected, time, WiFi, power state, etc.) | yes | yes (new) |
| Automation event | no | no |
| Tray "Run", CLI quick action, "Run Now" button | yes or no | no (out of scope for this issue, easy follow-up) |

### Reproduction (for reviewers with hardware)
1. Configure two pipelines A and B as quick actions (no triggers), and add both to the smart-key single-press cycle. Set the smart-key single-press action to A.
2. Add a third pipeline triggered "When a game starts" that runs B.
3. Start a game. The automation runs B. Press the smart key.
4. Without this PR, smart key runs B again. With this PR, smart key runs A and the cycle continues normally.
5. Repeat with the double-press list to verify both lists advance independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Smart key actions now properly cycle through all configured sequences when triggered
  * Enhanced synchronization of smart key settings ensures correct state persistence across automation operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->