### PR TITLE
Fix pipe message framing in IPC ReadObjectAsync

### DIFF
--- a/LenovoLegionToolkit.CLI.Lib/Extensions/PipeStreamExtensions.cs
+++ b/LenovoLegionToolkit.CLI.Lib/Extensions/PipeStreamExtensions.cs
@@ -27,14 +27,15 @@ public static class PipeStreamExtensions
             throw new InvalidOperationException("ReadMode is not PipeTransmissionMode.Message");
 
         var buffer = new byte[1024];
-        var builder = new StringBuilder();
+        using var ms = new global::System.IO.MemoryStream();
 
         do
         {
-            _ = await stream.ReadAsync(buffer, token).ConfigureAwait(false);
-            builder.Append(Encoding.GetString(buffer));
+            var read = await stream.ReadAsync(buffer, token).ConfigureAwait(false);
+            if (read <= 0) break;
+            ms.Write(buffer, 0, read);
         } while (!stream.IsMessageComplete);
 
-        return JsonConvert.DeserializeObject<T>(builder.ToString());
+        return JsonConvert.DeserializeObject<T>(Encoding.GetString(ms.GetBuffer(), 0, (int)ms.Length));
     }
 }


### PR DESCRIPTION
# Pull Request

## Description

`PipeStreamExtensions.ReadObjectAsync` discards the byte count returned by `PipeStream.ReadAsync` and decodes the entire 1024-byte buffer on every iteration. For any IPC message whose total size is not a multiple of 1024, the final read returns fewer than 1024 bytes; the trailing bytes of the buffer still contain leftover data from the previous iteration; that leftover gets appended to the assembled JSON string; Newtonsoft then rejects the result with:

```
JsonReaderException: Additional text encountered after finished reading JSON content
```

The bug is latent for the IPC operations currently in the codebase because their typical payloads fit in a single read where the unwritten buffer tail is initial zeros, and Newtonsoft tolerates trailing NUL bytes after a valid JSON value. It surfaces immediately for any new IPC operation whose response is greater than 1024 bytes, and would surface for `ListFeatures` / `ListQuickActions` on a machine with enough items to push the serialized response over the threshold.

### Reproduction

In `IpcServer.HandleRequest`, temporarily make any handler return a large payload:

```csharp
case IpcRequest.OperationType.ListFeatures:
    return new IpcResponse { Success = true, Message = new string('a', 5000) };
```

Run `LLT.exe feature -l` from the CLI:

```
Newtonsoft.Json.JsonReaderException: Additional text encountered after finished reading JSON content: a. Path '', line 1, position 5079.
   at LenovoLegionToolkit.CLI.Lib.Extensions.PipeStreamExtensions.ReadObjectAsync[T](PipeStream stream, CancellationToken token) in PipeStreamExtensions.cs:line 38
   at LenovoLegionToolkit.CLI.IpcClient.SendRequestAsync(IpcRequest req)
```

The `position` value in the error matches the actual JSON payload length, and the trailing character is the leftover byte from the prior buffer fill.

### Fix

Read into a `MemoryStream` using the actual byte count from each `ReadAsync` call, then UTF-8 decode once at the end. This both fixes the framing bug and incidentally fixes a latent correctness issue with multi-byte UTF-8 codepoints that span buffer boundaries (the prior implementation called `Encoding.UTF8.GetString` on each chunk independently, which can corrupt a codepoint whose bytes straddle the boundary).

### Scope

Single file, single method, 5-line diff. No behavioral change for messages ≤ 1024 bytes other than the (already correct) decode now happening once instead of once-per-iteration.

- Fixes: (no existing issue; happy to file one if preferred)

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility update (adding support for new hardware)
- [ ] Documentation update

## Hardware Verification Details

- **Device Series:** Legion Pro 7i Gen 10
- **Exact Model Number:** MachineType 83F5
- **BIOS Version:** Q7CN77WW
- **Operating System:** Windows 11, .NET 9 x64

## Testing Checklist
- [x] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [x] I have verified this change on physical hardware.
- [ ] I have included a video/screenshot of the change in action (highly preferred for UI changes). _(N/A — no UI change. Repro is text-based and included in the Description above.)_
- [x] My code follows the project's style guidelines.

## Additional Notes

The bug was discovered while prototyping a downstream feature that introduced a larger-payload IPC operation. The downstream feature itself is unrelated to this PR; only the framing fix is being proposed for upstream, since it stands on its own and applies regardless of how the IPC pipeline is used.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed data handling in internal communication to improve reliability and accuracy of message processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LenovoLegionToolkit-Team/LenovoLegionToolkit/pull/306?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->