### PR TITLE
Killing other existing instance when debugger attached before ensuring single instance

### DIFF
--- a/LenovoLegionToolkit.WPF/App.xaml.cs
+++ b/LenovoLegionToolkit.WPF/App.xaml.cs
@@ -138,11 +138,6 @@ public partial class App
 
     private async Task<bool> InitializeCoreEnvironmentAsync(StartupEventArgs e)
     {
-        if (!EnsureSingleInstance())
-        {
-            return false;
-        }
-
 #if DEBUG
         if (Debugger.IsAttached)
         {
@@ -164,6 +159,11 @@ public partial class App
         {
             InitializeDebugConsole();
             Console.WriteLine(@"[Startup] Ensuring Single Instance...");
+        }
+
+        if (!EnsureSingleInstance())
+        {
+            return false;
         }
 
         await Compatibility.PrintMachineInfoAsync().ConfigureAwait(false);


### PR DESCRIPTION
## Description

- Fixes #308 

The change is quite obvious, no description needed.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility update (adding support for new hardware)
- [ ] Documentation update

## Testing Checklist
- [ ] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [x] I have verified this change on physical hardware.
- [ ] I have included a video/screenshot of the change in action (highly preferred for UI changes).
- [x] My code follows the project's style guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted application startup sequence.
  * Single-instance detection now runs after initial logging/console setup, changing how the app exits when another instance is already running.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LenovoLegionToolkit-Team/LenovoLegionToolkit/pull/309?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->