### PR TITLE
Low level keyboard event listener enhancement

### DIFF
--- a/LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs
+++ b/LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs
@@ -43,6 +43,8 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
     private HPOWERNOTIFY _powerSavingStateChangeNotificationHandle;
     private HHOOK _kbHook;
 
+    private bool _lastCapslockState;
+
     public bool IsMonitorOn { get; private set; }
     public bool IsLidOpen { get; private set; }
 
@@ -55,6 +57,7 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
         _smartFnLockController = smartFnLockController;
         _powerModeFeature = powerModeFeature;
 
+        _lastCapslockState = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
         _kbProc = LowLevelKeyboardProc;
     }
 
@@ -350,9 +353,16 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
 
         if (kbStruct.vkCode == (ulong)VIRTUAL_KEY.VK_CAPITAL)
         {
-            var isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
-            var type = isOn ? NotificationType.CapsLockOn : NotificationType.CapsLockOff;
-            MessagingCenter.Publish(new NotificationMessage(type));
+            Task.Delay(50).ContinueWith(t =>
+            {
+                var isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
+                if (isOn != _lastCapslockState)
+                {
+                    _lastCapslockState = isOn;
+                    var type = isOn ? NotificationType.CapsLockOn : NotificationType.CapsLockOff;
+                    MessagingCenter.Publish(new NotificationMessage(type));
+                }
+            });
         }
 
         if (kbStruct.vkCode == (ulong)VIRTUAL_KEY.VK_NUMLOCK)

--- a/LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs
+++ b/LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs
@@ -353,16 +353,9 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
 
         if (kbStruct.vkCode == (ulong)VIRTUAL_KEY.VK_CAPITAL)
         {
-            Task.Delay(50).ContinueWith(t =>
-            {
-                var isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
-                if (isOn != _lastCapslockState)
-                {
-                    _lastCapslockState = isOn;
-                    var type = isOn ? NotificationType.CapsLockOn : NotificationType.CapsLockOff;
-                    MessagingCenter.Publish(new NotificationMessage(type));
-                }
-            });
+            var isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
+            var type = isOn ? NotificationType.CapsLockOn : NotificationType.CapsLockOff;
+            MessagingCenter.Publish(new NotificationMessage(type));
         }
 
         if (kbStruct.vkCode == (ulong)VIRTUAL_KEY.VK_NUMLOCK)

--- a/LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs
+++ b/LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs
@@ -21,6 +21,9 @@ namespace LenovoLegionToolkit.Lib.Listeners;
 
 public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindowsMessageListener.ChangedEventArgs>
 {
+    private const uint WM_APP_CHECK_CAPS = PInvoke.WM_APP + 0;
+    private const uint WM_APP_CHECK_NUMLOCK = PInvoke.WM_APP + 1;
+
     public class ChangedEventArgs(NativeWindowsMessage message, object? data = null) : EventArgs
     {
         public NativeWindowsMessage Message { get; } = message;
@@ -44,6 +47,7 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
     private HHOOK _kbHook;
 
     private bool _lastCapslockState;
+    private bool _lastNumlockState;
 
     public bool IsMonitorOn { get; private set; }
     public bool IsLidOpen { get; private set; }
@@ -58,6 +62,7 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
         _powerModeFeature = powerModeFeature;
 
         _lastCapslockState = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
+        _lastNumlockState = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_NUMLOCK) & 0x1) != 0;
         _kbProc = LowLevelKeyboardProc;
     }
 
@@ -199,6 +204,28 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
                 Log.Instance.Trace($"Event received: Battery Saver enabled");
 
                 OnBatterySaverEnabled();
+            }
+        }
+
+        if (m.Msg == WM_APP_CHECK_CAPS)
+        {
+            var isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
+            if (isOn != _lastCapslockState)
+            {
+                _lastCapslockState = isOn;
+                var type = isOn ? NotificationType.CapsLockOn : NotificationType.CapsLockOff;
+                MessagingCenter.Publish(new NotificationMessage(type));
+            }
+        }
+
+        if (m.Msg == WM_APP_CHECK_NUMLOCK)
+        {
+            var isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_NUMLOCK) & 0x1) != 0;
+            if (isOn != _lastNumlockState)
+            {
+                _lastNumlockState = isOn;
+                var type = isOn ? NotificationType.NumLockOn : NotificationType.NumLockOff;
+                MessagingCenter.Publish(new NotificationMessage(type));
             }
         }
 
@@ -352,18 +379,10 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
             return PInvoke.CallNextHookEx(HHOOK.Null, nCode, wParam, lParam);
 
         if (kbStruct.vkCode == (ulong)VIRTUAL_KEY.VK_CAPITAL)
-        {
-            var isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_CAPITAL) & 0x1) != 0;
-            var type = isOn ? NotificationType.CapsLockOn : NotificationType.CapsLockOff;
-            MessagingCenter.Publish(new NotificationMessage(type));
-        }
+            PInvoke.PostMessage(new HWND(Handle), WM_APP_CHECK_CAPS, 0, 0);
 
         if (kbStruct.vkCode == (ulong)VIRTUAL_KEY.VK_NUMLOCK)
-        {
-            var isOn = (PInvoke.GetKeyState((int)VIRTUAL_KEY.VK_NUMLOCK) & 0x1) != 0;
-            var type = isOn ? NotificationType.NumLockOn : NotificationType.NumLockOff;
-            MessagingCenter.Publish(new NotificationMessage(type));
-        }
+            PInvoke.PostMessage(new HWND(Handle), WM_APP_CHECK_NUMLOCK, 0, 0);
 
         return PInvoke.CallNextHookEx(HHOOK.Null, nCode, wParam, lParam);
     }

--- a/LenovoLegionToolkit.Lib/NativeMethods.txt
+++ b/LenovoLegionToolkit.Lib/NativeMethods.txt
@@ -1,5 +1,6 @@
 HWND_BROADCAST
 
+WM_APP
 WM_CLOSE
 WM_COMMAND
 WM_DESTROY
@@ -186,6 +187,7 @@ GetDpiForMonitor
 
 RegNotifyChangeKeyValue
 
+PostMessage
 SendInput
 SendMessage
 SendNotifyMessage


### PR DESCRIPTION
## Description

- Fixes #310

Post self-defined msgs (`WM_APP_CHECK_CAPS` & `WM_APP_CHECK_NUMLOCK`) into the Message Window's msg queue when the low level keyboard hook receives these certain keys' KEY_UP events, to tell `WndProc()` that these keys' state should be checked.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility update (adding support for new hardware)
- [ ] Documentation update

## Testing Checklist
- [ ] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [x] I have verified this change on physical hardware.
- [x] I have included a video/screenshot of the change in action (highly preferred for UI changes).
- [x] My code follows the project's style guidelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Caps Lock state detection accuracy to ensure reliable and timely notifications when the Caps Lock state changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/LenovoLegionToolkit-Team/LenovoLegionToolkit/pull/311?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->