### PR TITLE
Scope hardware sensor updates

### DIFF
--- a/LenovoLegionToolkit.Lib/Controllers/Sensors/SensorsGroupController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/Sensors/SensorsGroupController.cs
@@ -17,6 +17,19 @@ using LibreHardwareMonitor.Hardware;
 
 namespace LenovoLegionToolkit.Lib.Controllers.Sensors;
 
+[Flags]
+public enum HardwareUpdateScope
+{
+    None = 0,
+    Cpu = 1,
+    Gpu = 2,
+    Memory = 4,
+    Fans = 8,
+    Storage = 16,
+    AllNonStorage = Cpu | Gpu | Memory | Fans,
+    All = AllNonStorage | Storage
+}
+
 public class SensorsGroupController : IDisposable
 {
     #region Constants (Magic Words & Numbers)
@@ -165,13 +178,18 @@ public class SensorsGroupController : IDisposable
     private long _lastUpdateTick;
     private const int MIN_UPDATE_INTERVAL_MS = 100;
 
-    private readonly Dictionary<object, TimeSpan> _subscribers = [];
+    private readonly Dictionary<object, SensorSubscription> _subscribers = [];
     private CancellationTokenSource? _producerCts;
     private Task? _producerTask;
     public event Action<HardwareSensorSnapshot>? SensorsUpdated;
 
     private readonly GPUController _gpuController = IoCContainer.Resolve<GPUController>();
 
+    private readonly struct SensorSubscription(TimeSpan interval, HardwareUpdateScope scope)
+    {
+        public TimeSpan Interval { get; } = interval;
+        public HardwareUpdateScope Scope { get; } = scope;
+    }
 
     public async Task<LibreHardwareMonitorInitialState> IsSupportedAsync()
     {
@@ -503,7 +521,7 @@ public class SensorsGroupController : IDisposable
     private Task? _activeUpdateTask;
     private readonly Lock _updateTaskLock = new();
 
-    public async Task UpdateAsync(bool force = false)
+    public async Task UpdateAsync(bool force = false, HardwareUpdateScope scope = HardwareUpdateScope.All)
     {
         if (_isResetting || !IsLibreHardwareMonitorInitialized()) return;
 
@@ -515,7 +533,7 @@ public class SensorsGroupController : IDisposable
         {
             if (_activeUpdateTask == null)
             {
-                _activeUpdateTask = PerformUpdateInternal(force);
+                _activeUpdateTask = PerformUpdateInternal(scope);
             }
             updateTask = _activeUpdateTask;
         }
@@ -524,7 +542,7 @@ public class SensorsGroupController : IDisposable
             await updateTask.ConfigureAwait(false);
     }
 
-    private async Task PerformUpdateInternal(bool force)
+    private async Task PerformUpdateInternal(HardwareUpdateScope scope)
     {
         try
         {
@@ -545,7 +563,7 @@ public class SensorsGroupController : IDisposable
                         foreach (var h in _hardware)
                         {
                             if (h == null) continue;
-                            if (gpuInactive && h.HardwareType == HardwareType.GpuNvidia) continue;
+                            if (!ShouldUpdateHardware(h, scope, gpuInactive)) continue;
                             try
                             {
                                 h.Update();
@@ -672,8 +690,13 @@ public class SensorsGroupController : IDisposable
                         }
 
                         double memMaxTemp = _memoryTempSensors.Count > 0 ? (double)(_memoryTempSensors.Max(s => s.Value) ?? 0) : INVALID_VALUE_DOUBLE;
-                        float t1 = _storageTempSensors.Count > 0 ? _storageTempSensors[0].Value ?? INVALID_VALUE_FLOAT : INVALID_VALUE_FLOAT;
-                        float t2 = _storageTempSensors.Count > 1 ? _storageTempSensors[1].Value ?? INVALID_VALUE_FLOAT : INVALID_VALUE_FLOAT;
+                        var ssdTemps = Snapshot.SsdTemps;
+                        if (Includes(scope, HardwareUpdateScope.Storage))
+                        {
+                            float t1 = _storageTempSensors.Count > 0 ? _storageTempSensors[0].Value ?? INVALID_VALUE_FLOAT : INVALID_VALUE_FLOAT;
+                            float t2 = _storageTempSensors.Count > 1 ? _storageTempSensors[1].Value ?? INVALID_VALUE_FLOAT : INVALID_VALUE_FLOAT;
+                            ssdTemps = (t1, t2);
+                        }
 
                         Snapshot = new HardwareSensorSnapshot
                         {
@@ -698,7 +721,7 @@ public class SensorsGroupController : IDisposable
                             MemUsed = memUsed,
                             MemTotal = memTotal,
                             MemMaxTemp = memMaxTemp,
-                            SsdTemps = (t1, t2)
+                            SsdTemps = ssdTemps
                         };
 
                         SensorsUpdated?.Invoke(Snapshot);
@@ -769,11 +792,13 @@ public class SensorsGroupController : IDisposable
     public bool IsGpuInActive(GPUState state) => state is GPUState.Inactive or GPUState.PoweredOff or GPUState.Unknown or GPUState.NvidiaGpuNotFound;
     public bool IsLibreHardwareMonitorInitialized() => InitialState is LibreHardwareMonitorInitialState.Initialized or LibreHardwareMonitorInitialState.Success;
 
-    public void Start(object subscriber, TimeSpan interval)
+    public void Start(object subscriber, TimeSpan interval) => Start(subscriber, interval, HardwareUpdateScope.All);
+
+    public void Start(object subscriber, TimeSpan interval, HardwareUpdateScope scope)
     {
         lock (_subscribers)
         {
-            _subscribers[subscriber] = interval;
+            _subscribers[subscriber] = new SensorSubscription(interval, scope);
             UpdateProducerLoop();
         }
     }
@@ -817,15 +842,17 @@ public class SensorsGroupController : IDisposable
         while (!token.IsCancellationRequested)
         {
             TimeSpan minInterval;
+            HardwareUpdateScope scope;
             lock (_subscribers)
             {
                 if (_subscribers.Count == 0) return;
-                minInterval = _subscribers.Values.Min();
+                minInterval = _subscribers.Values.Min(s => s.Interval);
+                scope = _subscribers.Values.Aggregate(HardwareUpdateScope.None, (current, s) => current | s.Scope);
             }
 
             try
             {
-                await UpdateAsync(true).ConfigureAwait(false);
+                await UpdateAsync(true, scope).ConfigureAwait(false);
 
                 await Task.Delay(minInterval, token).ConfigureAwait(false);
             }
@@ -840,6 +867,23 @@ public class SensorsGroupController : IDisposable
             }
         }
     }
+
+    private static bool ShouldUpdateHardware(IHardware hardware, HardwareUpdateScope scope, bool gpuInactive)
+    {
+        if (gpuInactive && hardware.HardwareType == HardwareType.GpuNvidia)
+            return false;
+
+        return hardware.HardwareType switch
+        {
+            HardwareType.Cpu => Includes(scope, HardwareUpdateScope.Cpu),
+            HardwareType.GpuAmd or HardwareType.GpuIntel or HardwareType.GpuNvidia => Includes(scope, HardwareUpdateScope.Gpu),
+            HardwareType.Memory => Includes(scope, HardwareUpdateScope.Memory),
+            HardwareType.Storage => Includes(scope, HardwareUpdateScope.Storage),
+            _ => Includes(scope, HardwareUpdateScope.Fans)
+        };
+    }
+
+    private static bool Includes(HardwareUpdateScope scope, HardwareUpdateScope flag) => (scope & flag) != 0;
 
     public void Dispose()
     {

--- a/LenovoLegionToolkit.Lib/Controllers/Sensors/SensorsGroupController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/Sensors/SensorsGroupController.cs
@@ -17,19 +17,6 @@ using LibreHardwareMonitor.Hardware;
 
 namespace LenovoLegionToolkit.Lib.Controllers.Sensors;
 
-[Flags]
-public enum HardwareUpdateScope
-{
-    None = 0,
-    Cpu = 1,
-    Gpu = 2,
-    Memory = 4,
-    Fans = 8,
-    Storage = 16,
-    AllNonStorage = Cpu | Gpu | Memory | Fans,
-    All = AllNonStorage | Storage
-}
-
 public class SensorsGroupController : IDisposable
 {
     #region Constants (Magic Words & Numbers)
@@ -547,10 +534,15 @@ public class SensorsGroupController : IDisposable
         try
         {
             var now = Environment.TickCount64;
+            _lastUpdateTick = now;
+
+            if (scope == HardwareUpdateScope.None)
+            {
+                return;
+            }
+
             var gpuState = await _gpuController.GetLastKnownStateAsync().ConfigureAwait(false);
             bool gpuInactive = IsGpuInActive(gpuState);
-
-            _lastUpdateTick = now;
 
             await Task.Run(() =>
             {
@@ -690,7 +682,7 @@ public class SensorsGroupController : IDisposable
                         }
 
                         double memMaxTemp = _memoryTempSensors.Count > 0 ? (double)(_memoryTempSensors.Max(s => s.Value) ?? 0) : INVALID_VALUE_DOUBLE;
-                        var ssdTemps = Snapshot.SsdTemps;
+                        var ssdTemps = (INVALID_VALUE_FLOAT, INVALID_VALUE_FLOAT);
                         if (Includes(scope, HardwareUpdateScope.Storage))
                         {
                             float t1 = _storageTempSensors.Count > 0 ? _storageTempSensors[0].Value ?? INVALID_VALUE_FLOAT : INVALID_VALUE_FLOAT;
@@ -735,10 +727,7 @@ public class SensorsGroupController : IDisposable
         }
         finally
         {
-            lock (_updateTaskLock)
-            {
-                _activeUpdateTask = null;
-            }
+            _activeUpdateTask = null;
         }
     }
 
@@ -879,8 +868,40 @@ public class SensorsGroupController : IDisposable
             HardwareType.GpuAmd or HardwareType.GpuIntel or HardwareType.GpuNvidia => Includes(scope, HardwareUpdateScope.Gpu),
             HardwareType.Memory => Includes(scope, HardwareUpdateScope.Memory),
             HardwareType.Storage => Includes(scope, HardwareUpdateScope.Storage),
-            _ => Includes(scope, HardwareUpdateScope.Fans)
+            _ => false
         };
+    }
+
+    public static HardwareUpdateScope BuildHardwareUpdateScope(bool hasCpu, bool hasGpu, bool hasMemory, bool hasFans, bool hasStorage)
+    {
+        var scope = HardwareUpdateScope.None;
+
+        if (hasCpu)
+        {
+            scope |= HardwareUpdateScope.Cpu;
+        }
+
+        if (hasGpu)
+        {
+            scope |= HardwareUpdateScope.Gpu;
+        }
+
+        if (hasMemory)
+        {
+            scope |= HardwareUpdateScope.Memory;
+        }
+
+        if (hasFans)
+        {
+            scope |= HardwareUpdateScope.Fans;
+        }
+
+        if (hasStorage)
+        {
+            scope |= HardwareUpdateScope.Storage;
+        }
+
+        return scope;
     }
 
     private static bool Includes(HardwareUpdateScope scope, HardwareUpdateScope flag) => (scope & flag) != 0;

--- a/LenovoLegionToolkit.Lib/Controllers/Sensors/SensorsGroupController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/Sensors/SensorsGroupController.cs
@@ -178,6 +178,65 @@ public class SensorsGroupController : IDisposable
         public HardwareUpdateScope Scope { get; } = scope;
     }
 
+    private static readonly IDisposable NoOpDisposable = new LambdaDisposable(() => { });
+
+    private static readonly SensorItem[] CpuSensorItems = [SensorItem.CpuUtilization, SensorItem.CpuFrequency, SensorItem.CpuTemperature, SensorItem.CpuPower];
+    private static readonly SensorItem[] GpuSensorItems = [SensorItem.GpuUtilization, SensorItem.GpuFrequency, SensorItem.GpuCoreTemperature, SensorItem.GpuVramTemperature, SensorItem.GpuTemperatures, SensorItem.GpuPower, SensorItem.GpuVramUtilization];
+    private static readonly SensorItem[] MemorySensorItems = [SensorItem.MemoryUtilization, SensorItem.MemoryTemperature];
+    private static readonly SensorItem[] FansSensorItems = [SensorItem.CpuFanSpeed, SensorItem.GpuFanSpeed, SensorItem.PchFanSpeed, SensorItem.PchTemperature];
+    private static readonly SensorItem[] StorageSensorItems = [SensorItem.Disk1Temperature, SensorItem.Disk2Temperature];
+
+    private static readonly OsdItem[] CpuOsdItems = [OsdItem.CpuFrequency, OsdItem.CpuPCoreFrequency, OsdItem.CpuECoreFrequency, OsdItem.CpuUtilization, OsdItem.CpuTemperature, OsdItem.CpuPower];
+    private static readonly OsdItem[] GpuOsdItems = [OsdItem.GpuFrequency, OsdItem.GpuUtilization, OsdItem.GpuTemperature, OsdItem.GpuVramUtilization, OsdItem.GpuVramTemperature, OsdItem.GpuPower];
+    private static readonly OsdItem[] MemoryOsdItems = [OsdItem.MemoryUtilization, OsdItem.MemoryTemperature];
+    private static readonly OsdItem[] FansOsdItems = [OsdItem.CpuFan, OsdItem.GpuFan, OsdItem.PchTemperature, OsdItem.PchFan];
+    private static readonly OsdItem[] StorageOsdItems = [OsdItem.Disk1Temperature, OsdItem.Disk2Temperature];
+
+    public IDisposable Subscribe(TimeSpan interval, IEnumerable<SensorItem> items)
+    {
+        var scope = ComputeScopeFromSensorItems(items);
+        if (scope == HardwareUpdateScope.None)
+            return NoOpDisposable;
+        return Subscribe(interval, scope);
+    }
+
+    public IDisposable Subscribe(TimeSpan interval, IEnumerable<OsdItem> items)
+    {
+        var scope = ComputeScopeFromOsdItems(items);
+        if (scope == HardwareUpdateScope.None)
+            return NoOpDisposable;
+        return Subscribe(interval, scope);
+    }
+
+    public IDisposable Subscribe(TimeSpan interval, HardwareUpdateScope scope)
+    {
+        var key = new object();
+        Start(key, interval, scope);
+        return new LambdaDisposable(() => Stop(key));
+    }
+
+    private static HardwareUpdateScope ComputeScopeFromSensorItems(IEnumerable<SensorItem> items)
+    {
+        var set = items as HashSet<SensorItem> ?? new HashSet<SensorItem>(items);
+        return BuildHardwareUpdateScope(
+            hasCpu: set.Overlaps(CpuSensorItems),
+            hasGpu: set.Overlaps(GpuSensorItems),
+            hasMemory: set.Overlaps(MemorySensorItems),
+            hasFans: set.Overlaps(FansSensorItems),
+            hasStorage: set.Overlaps(StorageSensorItems));
+    }
+
+    private static HardwareUpdateScope ComputeScopeFromOsdItems(IEnumerable<OsdItem> items)
+    {
+        var set = items as HashSet<OsdItem> ?? new HashSet<OsdItem>(items);
+        return BuildHardwareUpdateScope(
+            hasCpu: set.Overlaps(CpuOsdItems),
+            hasGpu: set.Overlaps(GpuOsdItems),
+            hasMemory: set.Overlaps(MemoryOsdItems),
+            hasFans: set.Overlaps(FansOsdItems),
+            hasStorage: set.Overlaps(StorageOsdItems));
+    }
+
     public async Task<LibreHardwareMonitorInitialState> IsSupportedAsync()
     {
         LibreHardwareMonitorInitialState result = await InitializeAsync().ConfigureAwait(false);

--- a/LenovoLegionToolkit.Lib/Enums.cs
+++ b/LenovoLegionToolkit.Lib/Enums.cs
@@ -394,6 +394,19 @@ public enum MicrophoneState
     On
 }
 
+[Flags]
+public enum HardwareUpdateScope
+{
+    None = 0,
+    Cpu = 1,
+    Gpu = 2,
+    Memory = 4,
+    Fans = 8,
+    Storage = 16,
+    AllNonStorage = Cpu | Gpu | Memory | Fans,
+    All = AllNonStorage | Storage
+}
+
 public enum HardwareSensorsState
 {
     [Display(ResourceType = typeof(Resource), Name = "HardwareSensorsState_Off")]

--- a/LenovoLegionToolkit.WPF/Controls/Dashboard/SensorsControlV2.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Dashboard/SensorsControlV2.xaml.cs
@@ -94,6 +94,8 @@ public partial class SensorsControlV2
                     }
 
                     UpdateControlsVisibility();
+                    if (IsVisible && _applicationSettings.Store.EnableHardwareSensors)
+                        StartSensorUpdates();
                 }
             });
         });
@@ -111,7 +113,7 @@ public partial class SensorsControlV2
                 else if (IsVisible)
                 {
                     _sensorsGroupControllers.SensorsUpdated += OnSensorsUpdated;
-                    _sensorsGroupControllers.Start(this, TimeSpan.FromSeconds(_sensorsControlSettings.Store.SensorsRefreshIntervalSeconds));
+                    StartSensorUpdates();
                 }
             });
         });
@@ -161,7 +163,7 @@ public partial class SensorsControlV2
                 InitializeContextMenu();
                 if (IsVisible)
                 {
-                    _sensorsGroupControllers.Start(this, TimeSpan.FromSeconds(interval));
+                    StartSensorUpdates(interval);
                 }
             };
             ContextMenu.Items.Add(item);
@@ -198,13 +200,65 @@ public partial class SensorsControlV2
                 return;
 
             _sensorsGroupControllers.SensorsUpdated += OnSensorsUpdated;
-            _sensorsGroupControllers.Start(this, TimeSpan.FromSeconds(_sensorsControlSettings.Store.SensorsRefreshIntervalSeconds));
+            StartSensorUpdates();
         }
         else
         {
             _sensorsGroupControllers.Stop(this);
             _sensorsGroupControllers.SensorsUpdated -= OnSensorsUpdated;
         }
+    }
+
+    private void StartSensorUpdates(double? intervalSeconds = null)
+    {
+        var interval = TimeSpan.FromSeconds(intervalSeconds ?? _sensorsControlSettings.Store.SensorsRefreshIntervalSeconds);
+        _sensorsGroupControllers.Start(this, interval, GetHardwareUpdateScope());
+    }
+
+    private HardwareUpdateScope GetHardwareUpdateScope()
+    {
+        var scope = HardwareUpdateScope.None;
+
+        if (_activeSensorItems.Overlaps([
+                SensorItem.CpuUtilization,
+                SensorItem.CpuFrequency,
+                SensorItem.CpuTemperature,
+                SensorItem.CpuPower
+            ]))
+            scope |= HardwareUpdateScope.Cpu;
+
+        if (_activeSensorItems.Overlaps([
+                SensorItem.GpuUtilization,
+                SensorItem.GpuFrequency,
+                SensorItem.GpuCoreTemperature,
+                SensorItem.GpuVramTemperature,
+                SensorItem.GpuTemperatures,
+                SensorItem.GpuPower,
+                SensorItem.GpuVramUtilization
+            ]))
+            scope |= HardwareUpdateScope.Gpu;
+
+        if (_activeSensorItems.Overlaps([
+                SensorItem.MemoryUtilization,
+                SensorItem.MemoryTemperature
+            ]))
+            scope |= HardwareUpdateScope.Memory;
+
+        if (_activeSensorItems.Overlaps([
+                SensorItem.CpuFanSpeed,
+                SensorItem.GpuFanSpeed,
+                SensorItem.PchFanSpeed,
+                SensorItem.PchTemperature
+            ]))
+            scope |= HardwareUpdateScope.Fans;
+
+        if (_activeSensorItems.Overlaps([
+                SensorItem.Disk1Temperature,
+                SensorItem.Disk2Temperature
+            ]))
+            scope |= HardwareUpdateScope.Storage;
+
+        return scope;
     }
 
     private async void OnSensorsUpdated(HardwareSensorSnapshot snapshot)

--- a/LenovoLegionToolkit.WPF/Controls/Dashboard/SensorsControlV2.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Dashboard/SensorsControlV2.xaml.cs
@@ -112,8 +112,8 @@ public partial class SensorsControlV2
                 }
                 else if (IsVisible)
                 {
-                    _sensorsGroupControllers.SensorsUpdated += OnSensorsUpdated;
                     StartSensorUpdates();
+                    _sensorsGroupControllers.SensorsUpdated += OnSensorsUpdated;
                 }
             });
         });
@@ -199,8 +199,8 @@ public partial class SensorsControlV2
             if (!_applicationSettings.Store.EnableHardwareSensors)
                 return;
 
-            _sensorsGroupControllers.SensorsUpdated += OnSensorsUpdated;
             StartSensorUpdates();
+            _sensorsGroupControllers.SensorsUpdated += OnSensorsUpdated;
         }
         else
         {
@@ -211,54 +211,29 @@ public partial class SensorsControlV2
 
     private void StartSensorUpdates(double? intervalSeconds = null)
     {
-        var interval = TimeSpan.FromSeconds(intervalSeconds ?? _sensorsControlSettings.Store.SensorsRefreshIntervalSeconds);
-        _sensorsGroupControllers.Start(this, interval, GetHardwareUpdateScope());
+        if (!_applicationSettings.Store.EnableHardwareSensors)
+        {
+            return;
+        }
+
+        var scope = GetHardwareUpdateScope();
+        if (scope == HardwareUpdateScope.None)
+        {
+            _sensorsGroupControllers.Stop(this);
+            return;
+        }
+
+        _sensorsGroupControllers.Start(this, TimeSpan.FromSeconds(intervalSeconds ?? _sensorsControlSettings.Store.SensorsRefreshIntervalSeconds), scope);
     }
 
     private HardwareUpdateScope GetHardwareUpdateScope()
     {
-        var scope = HardwareUpdateScope.None;
-
-        if (_activeSensorItems.Overlaps([
-                SensorItem.CpuUtilization,
-                SensorItem.CpuFrequency,
-                SensorItem.CpuTemperature,
-                SensorItem.CpuPower
-            ]))
-            scope |= HardwareUpdateScope.Cpu;
-
-        if (_activeSensorItems.Overlaps([
-                SensorItem.GpuUtilization,
-                SensorItem.GpuFrequency,
-                SensorItem.GpuCoreTemperature,
-                SensorItem.GpuVramTemperature,
-                SensorItem.GpuTemperatures,
-                SensorItem.GpuPower,
-                SensorItem.GpuVramUtilization
-            ]))
-            scope |= HardwareUpdateScope.Gpu;
-
-        if (_activeSensorItems.Overlaps([
-                SensorItem.MemoryUtilization,
-                SensorItem.MemoryTemperature
-            ]))
-            scope |= HardwareUpdateScope.Memory;
-
-        if (_activeSensorItems.Overlaps([
-                SensorItem.CpuFanSpeed,
-                SensorItem.GpuFanSpeed,
-                SensorItem.PchFanSpeed,
-                SensorItem.PchTemperature
-            ]))
-            scope |= HardwareUpdateScope.Fans;
-
-        if (_activeSensorItems.Overlaps([
-                SensorItem.Disk1Temperature,
-                SensorItem.Disk2Temperature
-            ]))
-            scope |= HardwareUpdateScope.Storage;
-
-        return scope;
+        return SensorsGroupController.BuildHardwareUpdateScope(
+            hasCpu: _activeSensorItems.Overlaps([SensorItem.CpuUtilization, SensorItem.CpuFrequency, SensorItem.CpuTemperature, SensorItem.CpuPower]),
+            hasGpu: _activeSensorItems.Overlaps([SensorItem.GpuUtilization, SensorItem.GpuFrequency, SensorItem.GpuCoreTemperature, SensorItem.GpuVramTemperature, SensorItem.GpuTemperatures, SensorItem.GpuPower, SensorItem.GpuVramUtilization]),
+            hasMemory: _activeSensorItems.Overlaps([SensorItem.MemoryUtilization, SensorItem.MemoryTemperature]),
+            hasFans: _activeSensorItems.Overlaps([SensorItem.CpuFanSpeed, SensorItem.GpuFanSpeed, SensorItem.PchFanSpeed, SensorItem.PchTemperature]),
+            hasStorage: _activeSensorItems.Overlaps([SensorItem.Disk1Temperature, SensorItem.Disk2Temperature]));
     }
 
     private async void OnSensorsUpdated(HardwareSensorSnapshot snapshot)

--- a/LenovoLegionToolkit.WPF/Controls/Dashboard/SensorsControlV2.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Dashboard/SensorsControlV2.xaml.cs
@@ -31,6 +31,7 @@ public partial class SensorsControlV2
     private readonly HardwareSensorSettings _hardwareSensorSettings = IoCContainer.Resolve<HardwareSensorSettings>();
     private readonly ApplicationSettings _applicationSettings = IoCContainer.Resolve<ApplicationSettings>();
     private readonly Lock _updateLock = new();
+    private IDisposable? _sensorSubscription;
     private readonly Task<string> _cpuNameTask;
     private Task<string>? _gpuNameTask;
     private readonly HashSet<SensorItem> _activeSensorItems = [];
@@ -106,7 +107,7 @@ public partial class SensorsControlV2
             {
                 if (message.State == HardwareSensorsState.Off)
                 {
-                    _sensorsGroupControllers.Stop(this);
+                    _sensorSubscription?.Dispose();
                     _sensorsGroupControllers.SensorsUpdated -= OnSensorsUpdated;
                     ClearAllSensorValues();
                 }
@@ -204,36 +205,22 @@ public partial class SensorsControlV2
         }
         else
         {
-            _sensorsGroupControllers.Stop(this);
+            _sensorSubscription?.Dispose();
             _sensorsGroupControllers.SensorsUpdated -= OnSensorsUpdated;
         }
     }
 
     private void StartSensorUpdates(double? intervalSeconds = null)
     {
+        _sensorSubscription?.Dispose();
+
         if (!_applicationSettings.Store.EnableHardwareSensors)
-        {
             return;
-        }
 
-        var scope = GetHardwareUpdateScope();
-        if (scope == HardwareUpdateScope.None)
-        {
-            _sensorsGroupControllers.Stop(this);
+        if (_activeSensorItems.Count == 0)
             return;
-        }
 
-        _sensorsGroupControllers.Start(this, TimeSpan.FromSeconds(intervalSeconds ?? _sensorsControlSettings.Store.SensorsRefreshIntervalSeconds), scope);
-    }
-
-    private HardwareUpdateScope GetHardwareUpdateScope()
-    {
-        return SensorsGroupController.BuildHardwareUpdateScope(
-            hasCpu: _activeSensorItems.Overlaps([SensorItem.CpuUtilization, SensorItem.CpuFrequency, SensorItem.CpuTemperature, SensorItem.CpuPower]),
-            hasGpu: _activeSensorItems.Overlaps([SensorItem.GpuUtilization, SensorItem.GpuFrequency, SensorItem.GpuCoreTemperature, SensorItem.GpuVramTemperature, SensorItem.GpuTemperatures, SensorItem.GpuPower, SensorItem.GpuVramUtilization]),
-            hasMemory: _activeSensorItems.Overlaps([SensorItem.MemoryUtilization, SensorItem.MemoryTemperature]),
-            hasFans: _activeSensorItems.Overlaps([SensorItem.CpuFanSpeed, SensorItem.GpuFanSpeed, SensorItem.PchFanSpeed, SensorItem.PchTemperature]),
-            hasStorage: _activeSensorItems.Overlaps([SensorItem.Disk1Temperature, SensorItem.Disk2Temperature]));
+        _sensorSubscription = _sensorsGroupControllers.Subscribe(TimeSpan.FromSeconds(intervalSeconds ?? _sensorsControlSettings.Store.SensorsRefreshIntervalSeconds), _activeSensorItems);
     }
 
     private async void OnSensorsUpdated(HardwareSensorSnapshot snapshot)

--- a/LenovoLegionToolkit.WPF/Converters/EnumToLocalizedStringConverter.cs
+++ b/LenovoLegionToolkit.WPF/Converters/EnumToLocalizedStringConverter.cs
@@ -1,4 +1,5 @@
-﻿using LenovoLegionToolkit.WPF.Resources;
+﻿using LenovoLegionToolkit.Lib;
+using LenovoLegionToolkit.WPF.Resources;
 
 namespace LenovoLegionToolkit.WPF.Converters
 {

--- a/LenovoLegionToolkit.WPF/Enums.cs
+++ b/LenovoLegionToolkit.WPF/Enums.cs
@@ -89,31 +89,6 @@ public enum SensorGroupType
     Disk
 }
 
-public enum SensorItem
-{
-    CpuUtilization,
-    CpuFrequency,
-    CpuFanSpeed,
-    CpuTemperature,
-    CpuPower,
-    GpuUtilization,
-    GpuFrequency,
-    GpuFanSpeed,
-    GpuCoreTemperature,
-    GpuVramTemperature,
-    GpuTemperatures,
-    GpuPower,
-    PchFanSpeed,
-    PchTemperature,
-    BatteryState,
-    BatteryLevel,
-    MemoryUtilization,
-    MemoryTemperature,
-    Disk1Temperature,
-    Disk2Temperature,
-    GpuVramUtilization
-}
-
 public enum SnackbarType
 {
     Success,

--- a/LenovoLegionToolkit.WPF/Settings/SensorsControlSettings.cs
+++ b/LenovoLegionToolkit.WPF/Settings/SensorsControlSettings.cs
@@ -1,4 +1,5 @@
 using System.Linq;
+using LenovoLegionToolkit.Lib;
 using LenovoLegionToolkit.Lib.Settings;
 
 namespace LenovoLegionToolkit.WPF.Settings;

--- a/LenovoLegionToolkit.WPF/Windows/Dashboard/EditSensorGroupWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Dashboard/EditSensorGroupWindow.xaml.cs
@@ -119,8 +119,7 @@ public partial class EditSensorGroupWindow
         _settings.Store.VisibleItems = selectedItems.ToArray();
         _settings.SynchronizeStore();
 
-        var libItems = Array.ConvertAll(_settings.Store.VisibleItems, x => (Lib.SensorItem)(int)x);
-        MessagingCenter.Publish(new DashboardElementChangedMessage(libItems));
+        MessagingCenter.Publish(new DashboardElementChangedMessage(_settings.Store.VisibleItems));
 
         Apply?.Invoke(this, EventArgs.Empty);
         Close();

--- a/LenovoLegionToolkit.WPF/Windows/Osd/OsdWindowBase.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Osd/OsdWindowBase.cs
@@ -137,6 +137,8 @@ public abstract class OsdWindowBase : Window
 
                 _activeItems = newItemsSet;
                 UpdateMeasurementControlsVisibility();
+                if (IsVisible && _applicationSettings.Store.EnableHardwareSensors)
+                    StartHardwareSensorUpdates();
             });
         });
 
@@ -341,7 +343,7 @@ public abstract class OsdWindowBase : Window
             CheckAndUpdateFpsMonitoring();
             UpdateMeasurementControlsVisibility();
 
-            _sensorsGroupControllers.Start(this, TimeSpan.FromSeconds(_OsdSettings.Store.OsdRefreshInterval));
+            StartHardwareSensorUpdates();
 
             await TheRing(_cts.Token);
         }
@@ -351,6 +353,58 @@ public abstract class OsdWindowBase : Window
             _sensorsGroupControllers.Stop(this);
             CheckAndUpdateFpsMonitoring();
         }
+    }
+
+    private void StartHardwareSensorUpdates()
+    {
+        _sensorsGroupControllers.Start(this, TimeSpan.FromSeconds(_OsdSettings.Store.OsdRefreshInterval), GetHardwareUpdateScope());
+    }
+
+    private HardwareUpdateScope GetHardwareUpdateScope()
+    {
+        var scope = HardwareUpdateScope.None;
+
+        if (_activeItems.Overlaps([
+                OsdItem.CpuFrequency,
+                OsdItem.CpuPCoreFrequency,
+                OsdItem.CpuECoreFrequency,
+                OsdItem.CpuUtilization,
+                OsdItem.CpuTemperature,
+                OsdItem.CpuPower
+            ]))
+            scope |= HardwareUpdateScope.Cpu;
+
+        if (_activeItems.Overlaps([
+                OsdItem.GpuFrequency,
+                OsdItem.GpuUtilization,
+                OsdItem.GpuTemperature,
+                OsdItem.GpuVramUtilization,
+                OsdItem.GpuVramTemperature,
+                OsdItem.GpuPower
+            ]))
+            scope |= HardwareUpdateScope.Gpu;
+
+        if (_activeItems.Overlaps([
+                OsdItem.MemoryUtilization,
+                OsdItem.MemoryTemperature
+            ]))
+            scope |= HardwareUpdateScope.Memory;
+
+        if (_activeItems.Overlaps([
+                OsdItem.CpuFan,
+                OsdItem.GpuFan,
+                OsdItem.PchTemperature,
+                OsdItem.PchFan
+            ]))
+            scope |= HardwareUpdateScope.Fans;
+
+        if (_activeItems.Overlaps([
+                OsdItem.Disk1Temperature,
+                OsdItem.Disk2Temperature
+            ]))
+            scope |= HardwareUpdateScope.Storage;
+
+        return scope;
     }
 
     private void OnWindowClosed(object? sender, EventArgs e)

--- a/LenovoLegionToolkit.WPF/Windows/Osd/OsdWindowBase.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Osd/OsdWindowBase.cs
@@ -66,6 +66,7 @@ public abstract class OsdWindowBase : Window
     private long _lastFpsUiUpdateTick;
 
     private CancellationTokenSource? _cts;
+    private IDisposable? _sensorSubscription;
     protected bool _positionSet;
     private bool _fpsMonitoringStarted;
     private bool _hasLenovoController;
@@ -350,33 +351,22 @@ public abstract class OsdWindowBase : Window
         else
         {
             _cts?.Cancel();
-            _sensorsGroupControllers.Stop(this);
+            _sensorSubscription?.Dispose();
             CheckAndUpdateFpsMonitoring();
         }
     }
 
     private void StartHardwareSensorUpdates()
     {
-        if (!_applicationSettings.Store.EnableHardwareSensors) return;
+        _sensorSubscription?.Dispose();
 
-        var scope = GetHardwareUpdateScope();
-        if (scope == HardwareUpdateScope.None)
-        {
-            _sensorsGroupControllers.Stop(this);
+        if (!_applicationSettings.Store.EnableHardwareSensors)
             return;
-        }
 
-        _sensorsGroupControllers.Start(this, TimeSpan.FromSeconds(_OsdSettings.Store.OsdRefreshInterval), scope);
-    }
+        if (_activeItems.Count == 0)
+            return;
 
-    private HardwareUpdateScope GetHardwareUpdateScope()
-    {
-        return SensorsGroupController.BuildHardwareUpdateScope(
-            hasCpu: _activeItems.Overlaps([OsdItem.CpuFrequency, OsdItem.CpuPCoreFrequency, OsdItem.CpuECoreFrequency, OsdItem.CpuUtilization, OsdItem.CpuTemperature, OsdItem.CpuPower]),
-            hasGpu: _activeItems.Overlaps([OsdItem.GpuFrequency, OsdItem.GpuUtilization, OsdItem.GpuTemperature, OsdItem.GpuVramUtilization, OsdItem.GpuVramTemperature, OsdItem.GpuPower]),
-            hasMemory: _activeItems.Overlaps([OsdItem.MemoryUtilization, OsdItem.MemoryTemperature]),
-            hasFans: _activeItems.Overlaps([OsdItem.CpuFan, OsdItem.GpuFan, OsdItem.PchTemperature, OsdItem.PchFan]),
-            hasStorage: _activeItems.Overlaps([OsdItem.Disk1Temperature, OsdItem.Disk2Temperature]));
+        _sensorSubscription = _sensorsGroupControllers.Subscribe(TimeSpan.FromSeconds(_OsdSettings.Store.OsdRefreshInterval), _activeItems);
     }
 
     private void OnWindowClosed(object? sender, EventArgs e)

--- a/LenovoLegionToolkit.WPF/Windows/Osd/OsdWindowBase.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Osd/OsdWindowBase.cs
@@ -357,54 +357,26 @@ public abstract class OsdWindowBase : Window
 
     private void StartHardwareSensorUpdates()
     {
-        _sensorsGroupControllers.Start(this, TimeSpan.FromSeconds(_OsdSettings.Store.OsdRefreshInterval), GetHardwareUpdateScope());
+        if (!_applicationSettings.Store.EnableHardwareSensors) return;
+
+        var scope = GetHardwareUpdateScope();
+        if (scope == HardwareUpdateScope.None)
+        {
+            _sensorsGroupControllers.Stop(this);
+            return;
+        }
+
+        _sensorsGroupControllers.Start(this, TimeSpan.FromSeconds(_OsdSettings.Store.OsdRefreshInterval), scope);
     }
 
     private HardwareUpdateScope GetHardwareUpdateScope()
     {
-        var scope = HardwareUpdateScope.None;
-
-        if (_activeItems.Overlaps([
-                OsdItem.CpuFrequency,
-                OsdItem.CpuPCoreFrequency,
-                OsdItem.CpuECoreFrequency,
-                OsdItem.CpuUtilization,
-                OsdItem.CpuTemperature,
-                OsdItem.CpuPower
-            ]))
-            scope |= HardwareUpdateScope.Cpu;
-
-        if (_activeItems.Overlaps([
-                OsdItem.GpuFrequency,
-                OsdItem.GpuUtilization,
-                OsdItem.GpuTemperature,
-                OsdItem.GpuVramUtilization,
-                OsdItem.GpuVramTemperature,
-                OsdItem.GpuPower
-            ]))
-            scope |= HardwareUpdateScope.Gpu;
-
-        if (_activeItems.Overlaps([
-                OsdItem.MemoryUtilization,
-                OsdItem.MemoryTemperature
-            ]))
-            scope |= HardwareUpdateScope.Memory;
-
-        if (_activeItems.Overlaps([
-                OsdItem.CpuFan,
-                OsdItem.GpuFan,
-                OsdItem.PchTemperature,
-                OsdItem.PchFan
-            ]))
-            scope |= HardwareUpdateScope.Fans;
-
-        if (_activeItems.Overlaps([
-                OsdItem.Disk1Temperature,
-                OsdItem.Disk2Temperature
-            ]))
-            scope |= HardwareUpdateScope.Storage;
-
-        return scope;
+        return SensorsGroupController.BuildHardwareUpdateScope(
+            hasCpu: _activeItems.Overlaps([OsdItem.CpuFrequency, OsdItem.CpuPCoreFrequency, OsdItem.CpuECoreFrequency, OsdItem.CpuUtilization, OsdItem.CpuTemperature, OsdItem.CpuPower]),
+            hasGpu: _activeItems.Overlaps([OsdItem.GpuFrequency, OsdItem.GpuUtilization, OsdItem.GpuTemperature, OsdItem.GpuVramUtilization, OsdItem.GpuVramTemperature, OsdItem.GpuPower]),
+            hasMemory: _activeItems.Overlaps([OsdItem.MemoryUtilization, OsdItem.MemoryTemperature]),
+            hasFans: _activeItems.Overlaps([OsdItem.CpuFan, OsdItem.GpuFan, OsdItem.PchTemperature, OsdItem.PchFan]),
+            hasStorage: _activeItems.Overlaps([OsdItem.Disk1Temperature, OsdItem.Disk2Temperature]));
     }
 
     private void OnWindowClosed(object? sender, EventArgs e)
@@ -779,92 +751,51 @@ public abstract class OsdWindowBase : Window
     {
         var gs = _sensorsGroupControllers.Snapshot;
 
+        SensorsData? mainData = null;
         if (_hasLenovoController)
         {
-            var mainData = await _controller.GetDataAsync();
-
-            if (token.IsCancellationRequested) return;
-
-            if (_uiUpdateThrottleMs > 0 && (DateTime.Now - _lastUpdate).TotalMilliseconds < _uiUpdateThrottleMs) return;
-
-            _lastUpdate = DateTime.Now;
-
-            var snapshot = new SensorSnapshot
-            {
-                CpuUsage = gs.CpuUsage,
-                CpuFrequency = _sensorsGroupControllers.ShowAverageCpuFrequency ? gs.CpuAvgClock : gs.CpuMaxClock,
-                CpuPClock = _sensorsGroupControllers.ShowAverageCpuFrequency ? gs.CpuPAvgClock : gs.CpuPClock,
-                CpuEClock = _sensorsGroupControllers.ShowAverageCpuFrequency ? gs.CpuEAvgClock : gs.CpuEClock,
-                CpuTemp = gs.CpuTemp,
-                CpuPower = gs.CpuPower,
-                CpuFanSpeed = mainData.CPU.FanSpeed,
-
-                GpuUsage = gs.GpuUsage,
-                GpuFrequency = gs.GpuClock,
-                GpuTemp = gs.GpuTemp,
-                GpuVramUsage = gs.GpuVramUtilization,
-                GpuVramUsed = gs.GpuVramUsed,
-                GpuVramTotal = gs.GpuVramTotal,
-                GpuVramTemp = gs.GpuVramTemp,
-                GpuPower = gs.GpuPower,
-                GpuFanSpeed = mainData.GPU.FanSpeed,
-
-                MemUsage = gs.MemUsage,
-                MemUsed = gs.MemUsed,
-                MemTotal = gs.MemTotal,
-                MemTemp = (float)gs.MemMaxTemp,
-
-                PchTemp = mainData.PCH.Temperature,
-                PchFanSpeed = mainData.PCH.FanSpeed,
-
-                Disk1Temp = gs.SsdTemps.Item1,
-                Disk2Temp = gs.SsdTemps.Item2
-            };
-
-            await Dispatcher.BeginInvoke(() => UpdateSensorData(snapshot), DispatcherPriority.Normal);
+            mainData = await _controller.GetDataAsync();
         }
-        else
+
+        if (token.IsCancellationRequested) return;
+
+        if (_uiUpdateThrottleMs > 0 && (DateTime.Now - _lastUpdate).TotalMilliseconds < _uiUpdateThrottleMs) return;
+
+        _lastUpdate = DateTime.Now;
+
+        var snapshot = new SensorSnapshot
         {
-            if (token.IsCancellationRequested) return;
+            CpuUsage = gs.CpuUsage,
+            CpuFrequency = _sensorsGroupControllers.ShowAverageCpuFrequency ? gs.CpuAvgClock : gs.CpuMaxClock,
+            CpuPClock = _sensorsGroupControllers.ShowAverageCpuFrequency ? gs.CpuPAvgClock : gs.CpuPClock,
+            CpuEClock = _sensorsGroupControllers.ShowAverageCpuFrequency ? gs.CpuEAvgClock : gs.CpuEClock,
+            CpuTemp = gs.CpuTemp,
+            CpuPower = gs.CpuPower,
+            CpuFanSpeed = mainData?.CPU.FanSpeed ?? -1,
 
-            if (_uiUpdateThrottleMs > 0 && (DateTime.Now - _lastUpdate).TotalMilliseconds < _uiUpdateThrottleMs) return;
+            GpuUsage = gs.GpuUsage,
+            GpuFrequency = gs.GpuClock,
+            GpuTemp = gs.GpuTemp,
+            GpuVramUsage = gs.GpuVramUtilization,
+            GpuVramUsed = gs.GpuVramUsed,
+            GpuVramTotal = gs.GpuVramTotal,
+            GpuVramTemp = gs.GpuVramTemp,
+            GpuPower = gs.GpuPower,
+            GpuFanSpeed = mainData?.GPU.FanSpeed ?? -1,
 
-            _lastUpdate = DateTime.Now;
+            MemUsage = gs.MemUsage,
+            MemUsed = gs.MemUsed,
+            MemTotal = gs.MemTotal,
+            MemTemp = (float)gs.MemMaxTemp,
 
-            var snapshot = new SensorSnapshot
-            {
-                CpuUsage = gs.CpuUsage,
-                CpuFrequency = _sensorsGroupControllers.ShowAverageCpuFrequency ? gs.CpuAvgClock : gs.CpuMaxClock,
-                CpuPClock = _sensorsGroupControllers.ShowAverageCpuFrequency ? gs.CpuPAvgClock : gs.CpuPClock,
-                CpuEClock = _sensorsGroupControllers.ShowAverageCpuFrequency ? gs.CpuEAvgClock : gs.CpuEClock,
-                CpuTemp = gs.CpuTemp,
-                CpuPower = gs.CpuPower,
-                CpuFanSpeed = -1,
+            PchTemp = mainData?.PCH.Temperature ?? -1,
+            PchFanSpeed = mainData?.PCH.FanSpeed ?? -1,
 
-                GpuUsage = gs.GpuUsage,
-                GpuFrequency = gs.GpuClock,
-                GpuTemp = gs.GpuTemp,
-                GpuVramUsage = gs.GpuVramUtilization,
-                GpuVramUsed = gs.GpuVramUsed,
-                GpuVramTotal = gs.GpuVramTotal,
-                GpuVramTemp = gs.GpuVramTemp,
-                GpuPower = gs.GpuPower,
-                GpuFanSpeed = -1,
+            Disk1Temp = gs.SsdTemps.Item1,
+            Disk2Temp = gs.SsdTemps.Item2
+        };
 
-                MemUsage = gs.MemUsage,
-                MemUsed = gs.MemUsed,
-                MemTotal = gs.MemTotal,
-                MemTemp = (float)gs.MemMaxTemp,
-
-                PchTemp = -1,
-                PchFanSpeed = -1,
-
-                Disk1Temp = gs.SsdTemps.Item1,
-                Disk2Temp = gs.SsdTemps.Item2
-            };
-
-            await Dispatcher.BeginInvoke(() => UpdateSensorData(snapshot), DispatcherPriority.Normal);
-        }
+        await Dispatcher.BeginInvoke(() => UpdateSensorData(snapshot), DispatcherPriority.Normal);
     }
 
     protected abstract void UpdateSensorData(SensorSnapshot data);

--- a/LenovoLegionToolkit.WPF/Windows/Utils/StatusWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/StatusWindow.xaml.cs
@@ -264,28 +264,29 @@ public partial class StatusWindow
         SensorsData? sensorsData = null;
         double cpuPower = -1, gpuPower = -1, cpuClock = -1, cpuTemp = -1, gpuClock = -1, gpuTemp = -1;
 
-        var tasks = new List<Task>();
-
-        tasks.Add(Task.Run(async () => {
-            try
+        var tasks = new List<Task>
+        {
+            Task.Run(async () =>
             {
-                if (await _powerModeFeature.IsSupportedAsync().WaitAsync(token))
+                try
                 {
-                    state = await _powerModeFeature.GetStateAsync().WaitAsync(token);
-                    if (state == PowerModeState.GodMode) godModePresetName = await _godModeController.GetActivePresetNameAsync().WaitAsync(token);
+                    if (await _powerModeFeature.IsSupportedAsync().WaitAsync(token))
+                    {
+                        state = await _powerModeFeature.GetStateAsync().WaitAsync(token);
+                        if (state == PowerModeState.GodMode) godModePresetName = await _godModeController.GetActivePresetNameAsync().WaitAsync(token);
+                    }
+                    else if (await _itsModeFeature.IsSupportedAsync().WaitAsync(token))
+                    {
+                        mode = await _itsModeFeature.GetStateAsync().WaitAsync(token);
+                    }
                 }
-                else if (await _itsModeFeature.IsSupportedAsync().WaitAsync(token))
-                {
-                    mode = await _itsModeFeature.GetStateAsync().WaitAsync(token);
-                }
-            }
-            catch { /* Ignore */ }
-        }, token));
-
-        tasks.Add(Task.Run(async () => { try { if (_gpuController.IsSupported()) gpuStatus = await _gpuController.RefreshNowAsync().WaitAsync(token); } catch { } }, token));
-        tasks.Add(Task.Run(() => { try { batteryInfo = Battery.GetBatteryInformation(); } catch { } }, token));
-        tasks.Add(Task.Run(async () => { try { if (await _batteryFeature.IsSupportedAsync().WaitAsync(token)) batteryState = await _batteryFeature.GetStateAsync().WaitAsync(token); } catch { } }, token));
-        tasks.Add(Task.Run(async () => { try { if (_updateSettings.Store.UpdateCheckFrequency != UpdateCheckFrequency.Never) hasUpdate = await _updateChecker.CheckAsync(false).WaitAsync(token) is not null; } catch { } }, token));
+                catch { /* Ignore */ }
+            }, token),
+            Task.Run(async () => { try { if (_gpuController.IsSupported()) gpuStatus = await _gpuController.RefreshNowAsync().WaitAsync(token); } catch { } }, token),
+            Task.Run(() => { try { batteryInfo = Battery.GetBatteryInformation(); } catch { } }, token),
+            Task.Run(async () => { try { if (await _batteryFeature.IsSupportedAsync().WaitAsync(token)) batteryState = await _batteryFeature.GetStateAsync().WaitAsync(token); } catch { } }, token),
+            Task.Run(async () => { try { if (_updateSettings.Store.UpdateCheckFrequency != UpdateCheckFrequency.Never) hasUpdate = await _updateChecker.CheckAsync(false).WaitAsync(token) is not null; } catch { } }, token)
+        };
 
         await Task.WhenAll(tasks).ConfigureAwait(false);
 

--- a/LenovoLegionToolkit.WPF/Windows/Utils/StatusWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/StatusWindow.xaml.cs
@@ -217,7 +217,7 @@ public partial class StatusWindow
                 ? _sensorsControlSettings.Store.SensorsRefreshIntervalSeconds
                 : _dashboardSettings.Store.SensorsRefreshIntervalSeconds;
 
-            _sensorsGroupController.Start(this, TimeSpan.FromSeconds(refreshInterval));
+            _sensorsGroupController.Start(this, TimeSpan.FromSeconds(refreshInterval), HardwareUpdateScope.Cpu | HardwareUpdateScope.Gpu);
         }
         else
         {

--- a/LenovoLegionToolkit.WPF/Windows/Utils/StatusWindow.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Windows/Utils/StatusWindow.xaml.cs
@@ -48,6 +48,7 @@ public partial class StatusWindow
     private readonly SensorsController _sensorsController = IoCContainer.Resolve<SensorsController>();
     private readonly SensorsGroupController _sensorsGroupController = IoCContainer.Resolve<SensorsGroupController>();
     private readonly HardwareSensorSettings _hardwareSensorSettings = IoCContainer.Resolve<HardwareSensorSettings>();
+    private IDisposable? _sensorSubscription;
 
     private MachineInformation? _machineInfo;
     private Type? _cachedControllerType;
@@ -217,11 +218,12 @@ public partial class StatusWindow
                 ? _sensorsControlSettings.Store.SensorsRefreshIntervalSeconds
                 : _dashboardSettings.Store.SensorsRefreshIntervalSeconds;
 
-            _sensorsGroupController.Start(this, TimeSpan.FromSeconds(refreshInterval), HardwareUpdateScope.Cpu | HardwareUpdateScope.Gpu);
+            _sensorSubscription?.Dispose();
+            _sensorSubscription = _sensorsGroupController.Subscribe(TimeSpan.FromSeconds(refreshInterval), HardwareUpdateScope.Cpu | HardwareUpdateScope.Gpu);
         }
         else
         {
-            _sensorsGroupController.Stop(this);
+            _sensorSubscription?.Dispose();
             _sensorsGroupController.SensorsUpdated -= OnSensorsUpdated;
             _cancellationTokenSource.Cancel();
         }


### PR DESCRIPTION
## Summary
- Add scoped hardware sensor update flags for CPU, GPU, memory, fans, and storage.
- Update dashboard, OSD, and status window subscribers to request only the sensor groups they display.
- Keep SSD temperature values stable when storage sensors are not part of the requested update scope.

## Notes
- Excludes the CI signing certificate change from Dictation354/dev.

## Testing
- Not run: `dotnet` is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hardware sensor refresh can now target specific components (CPU, GPU, Memory, Fans, Storage) independently rather than always refreshing everything.

* **Improvements**
  * Dashboard and OSD sensor updates now start/stop automatically based on window visibility and active item selection.
  * Sensor refresh scheduling was refined to update only what’s currently needed, reducing unnecessary work.

* **Bug Fixes**
  * Storage/SSD temperature calculations are now only performed when Storage updates are included in the selected refresh scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->