### PR TITLE
Sync power mode from active Windows power plan

### DIFF
--- a/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
@@ -39,7 +39,7 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
     {
         if (Interlocked.Exchange(ref _skipNextPowerModeSync, 0) == 1)
         {
-            Log.Instance.Trace("Ignoring power plan change initiated by Lenovo Legion Toolkit.");
+            Log.Instance.Trace("Skipping power mode synchronization. [reason=power plan change initiated by LLT]");
             return null;
         }
 
@@ -54,7 +54,7 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
             if (powerPlan.Value == activePowerPlanGuid)
                 return powerPlan.Key;
 
-        Log.Instance.Trace($"Active power plan is not mapped to a power mode. [guid={activePowerPlanGuid}]");
+        Log.Instance.Trace($"Skipping power mode synchronization. [reason=active power plan is not mapped, guid={activePowerPlanGuid}]");
         return null;
     }
 

--- a/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
@@ -36,10 +36,13 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
 
     public PowerModeState? GetPowerModeStateForActivePowerPlan()
     {
-        if (settings.Store.PowerModeMappingMode is not PowerModeMappingMode.WindowsPowerPlan)
+        if (settings.Store.PowerModeMappingMode is not PowerModeMappingMode.WindowsPowerPlan ||
+            !settings.Store.SynchronizePowerModeWithWindowsPowerPlan)
             return null;
 
-        var activePowerPlanGuid = GetActivePowerPlanGuid();
+        if (!TryGetActivePowerPlanGuid(out var activePowerPlanGuid))
+            return null;
+
         foreach (var powerPlan in settings.Store.PowerPlans)
             if (powerPlan.Value == activePowerPlanGuid)
                 return powerPlan.Key;
@@ -459,19 +462,30 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
         }
     }
 
-    private static unsafe Guid GetActivePowerPlanGuid()
+    private static Guid GetActivePowerPlanGuid() => TryGetActivePowerPlanGuid(out var guid) ? guid : DefaultPowerPlan;
+
+    private static bool TryGetActivePowerPlanGuid(out Guid activePowerPlanGuid)
     {
         try
         {
-            if (PInvoke.PowerGetActiveScheme(null, out var guid) != WIN32_ERROR.ERROR_SUCCESS)
+            if (PowerGetActiveScheme(IntPtr.Zero, out var guid) != 0)
                 PInvokeExtensions.ThrowIfWin32Error("PowerGetActiveScheme");
 
-            return *guid;
+            try
+            {
+                activePowerPlanGuid = Marshal.PtrToStructure<Guid>(guid);
+                return true;
+            }
+            finally
+            {
+                LocalFree(guid);
+            }
         }
         catch (Exception ex)
         {
             Log.Instance.Trace($"Failed to get active power plan guid.", ex);
-            return DefaultPowerPlan;
+            activePowerPlanGuid = Guid.Empty;
+            return false;
         }
     }
 
@@ -480,4 +494,10 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
         if (PInvoke.PowerSetActiveScheme(null, powerPlanGuid) != WIN32_ERROR.ERROR_SUCCESS)
             PInvokeExtensions.ThrowIfWin32Error("PowerSetActiveScheme");
     }
+
+    [DllImport("kernel32.dll")]
+    private static extern IntPtr LocalFree(IntPtr hMem);
+
+    [DllImport("PowrProf.dll")]
+    private static extern uint PowerGetActiveScheme(IntPtr rootPowerKey, out IntPtr activePolicyGuid);
 }

--- a/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
@@ -23,6 +23,7 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
 
     private readonly ThrottleLastDispatcher _overlayDispatcher = new(TimeSpan.FromSeconds(2), nameof(WindowsPowerPlanController));
     private readonly SemaphoreSlim _lock = new(1, 1);
+    private int _skipNextPowerModeSync;
 
     public IEnumerable<WindowsPowerPlan> GetPowerPlans()
     {
@@ -36,6 +37,12 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
 
     public PowerModeState? GetPowerModeStateForActivePowerPlan()
     {
+        if (Interlocked.Exchange(ref _skipNextPowerModeSync, 0) == 1)
+        {
+            Log.Instance.Trace("Ignoring power plan change initiated by Lenovo Legion Toolkit.");
+            return null;
+        }
+
         if (settings.Store.PowerModeMappingMode is not PowerModeMappingMode.WindowsPowerPlan ||
             !settings.Store.SynchronizePowerModeWithWindowsPowerPlan)
             return null;
@@ -112,11 +119,13 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
 
             try
             {
+                Interlocked.Exchange(ref _skipNextPowerModeSync, 1);
                 SetActivePowerPlan(powerPlanToActivate.Guid);
                 Log.Instance.Trace($"Power plan {powerPlanToActivate.Guid} activated. [name={powerPlanToActivate.Name}]");
             }
             catch (Exception ex)
             {
+                Interlocked.Exchange(ref _skipNextPowerModeSync, 0);
                 Log.Instance.Trace($"Failed to set active power plan. [guid={powerPlanToActivate.Guid}]", ex);
                 return;
             }

--- a/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
@@ -468,8 +468,9 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
     {
         try
         {
-            if (PowerGetActiveScheme(IntPtr.Zero, out var guid) != 0)
-                PInvokeExtensions.ThrowIfWin32Error("PowerGetActiveScheme");
+            var result = PowerGetActiveScheme(IntPtr.Zero, out var guid);
+            if (result != 0)
+                PInvokeExtensions.ThrowIfWin32Error((int)result, "PowerGetActiveScheme");
 
             try
             {
@@ -491,8 +492,9 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
 
     private static void SetActivePowerPlan(Guid powerPlanGuid)
     {
-        if (PInvoke.PowerSetActiveScheme(null, powerPlanGuid) != WIN32_ERROR.ERROR_SUCCESS)
-            PInvokeExtensions.ThrowIfWin32Error("PowerSetActiveScheme");
+        var result = PInvoke.PowerSetActiveScheme(null, powerPlanGuid);
+        if (result != WIN32_ERROR.ERROR_SUCCESS)
+            PInvokeExtensions.ThrowIfWin32Error((int)result, "PowerSetActiveScheme");
     }
 
     [DllImport("kernel32.dll")]

--- a/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
@@ -34,6 +34,20 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
         }
     }
 
+    public PowerModeState? GetPowerModeStateForActivePowerPlan()
+    {
+        if (settings.Store.PowerModeMappingMode is not PowerModeMappingMode.WindowsPowerPlan)
+            return null;
+
+        var activePowerPlanGuid = GetActivePowerPlanGuid();
+        foreach (var powerPlan in settings.Store.PowerPlans)
+            if (powerPlan.Value == activePowerPlanGuid)
+                return powerPlan.Key;
+
+        Log.Instance.Trace($"Active power plan is not mapped to a power mode. [guid={activePowerPlanGuid}]");
+        return null;
+    }
+
     public async Task SetPowerPlanAsync(PowerModeState powerModeState, bool alwaysActivateDefaults = false, GodModeSettingsStore.Preset? preset = null, bool skipThrottle = false)
     {
         await _lock.WaitAsync().ConfigureAwait(false);

--- a/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using static LenovoLegionToolkit.Lib.Settings.GodModeSettings;
 
@@ -26,6 +27,8 @@ public class PowerModeFeature(
     PowerModeListener powerModeListener)
     : AbstractWmiFeature<PowerModeState>(WMI.LenovoGameZoneData.GetSmartFanModeAsync, WMI.LenovoGameZoneData.SetSmartFanModeAsync, WMI.LenovoGameZoneData.IsSupportSmartFanAsync, 1)
 {
+    private readonly SemaphoreSlim _activePowerPlanSyncLock = new(1, 1);
+
     public bool AllowAllPowerModesOnBattery { get; set; }
     public PowerModeState LastPowerModeState { get; set; }
 
@@ -132,15 +135,23 @@ public class PowerModeFeature(
 
     public async Task EnsureCorrectPowerModeIsSetForActivePowerPlanAsync()
     {
-        var state = windowsPowerPlanController.GetPowerModeStateForActivePowerPlan();
-        if (!state.HasValue)
-            return;
+        await _activePowerPlanSyncLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var state = windowsPowerPlanController.GetPowerModeStateForActivePowerPlan();
+            if (!state.HasValue)
+                return;
 
-        var currentState = await GetStateAsync().ConfigureAwait(false);
-        if (currentState == state.Value)
-            return;
+            var currentState = await GetStateAsync().ConfigureAwait(false);
+            if (currentState == state.Value)
+                return;
 
-        await SetStateAsync(state.Value).ConfigureAwait(false);
+            await SetStateAsync(state.Value).ConfigureAwait(false);
+        }
+        finally
+        {
+            _activePowerPlanSyncLock.Release();
+        }
     }
 
     public async Task EnsureGodModeStateIsAppliedAsync()

--- a/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
@@ -146,7 +146,14 @@ public class PowerModeFeature(
             if (currentState == state.Value)
                 return;
 
-            await SetStateAsync(state.Value).ConfigureAwait(false);
+            try
+            {
+                await SetStateAsync(state.Value).ConfigureAwait(false);
+            }
+            catch (PowerModeUnavailableWithoutACException)
+            {
+                Log.Instance.Trace($"Mapped power mode is unavailable. [state={state.Value}]");
+            }
         }
         finally
         {

--- a/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
@@ -152,7 +152,7 @@ public class PowerModeFeature(
             }
             catch (PowerModeUnavailableWithoutACException)
             {
-                Log.Instance.Trace($"Mapped power mode is unavailable. [state={state.Value}]");
+                Log.Instance.Trace($"Skipping power mode synchronization. [reason=mapped power mode is unavailable, state={state.Value}]");
             }
         }
         finally

--- a/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
@@ -130,6 +130,19 @@ public class PowerModeFeature(
         await windowsPowerPlanController.SetPowerPlanAsync(state, true, preset, skipThrottle).ConfigureAwait(false);
     }
 
+    public async Task EnsureCorrectPowerModeIsSetForActivePowerPlanAsync()
+    {
+        var state = windowsPowerPlanController.GetPowerModeStateForActivePowerPlan();
+        if (!state.HasValue)
+            return;
+
+        var currentState = await GetStateAsync().ConfigureAwait(false);
+        if (currentState == state.Value)
+            return;
+
+        await SetStateAsync(state.Value).ConfigureAwait(false);
+    }
+
     public async Task EnsureGodModeStateIsAppliedAsync()
     {
         var state = await GetStateAsync().ConfigureAwait(false);

--- a/LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs
+++ b/LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs
@@ -23,6 +23,7 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
 {
     private const uint WM_APP_CHECK_CAPS = PInvoke.WM_APP + 0;
     private const uint WM_APP_CHECK_NUMLOCK = PInvoke.WM_APP + 1;
+    private static readonly Guid ActivePowerSchemeGuid = Guid.Parse("31f9f286-5084-42fe-b720-2b0264993763");
 
     public class ChangedEventArgs(NativeWindowsMessage message, object? data = null) : EventArgs
     {
@@ -44,6 +45,7 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
     private HPOWERNOTIFY _consoleDisplayStateNotificationHandle;
     private HPOWERNOTIFY _lidSwitchStateChangeNotificationHandle;
     private HPOWERNOTIFY _powerSavingStateChangeNotificationHandle;
+    private HPOWERNOTIFY _activePowerSchemeNotificationHandle;
     private HHOOK _kbHook;
 
     private bool _lastCapslockState;
@@ -90,6 +92,7 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
         _consoleDisplayStateNotificationHandle = RegisterPowerNotification(PInvoke.GUID_CONSOLE_DISPLAY_STATE);
         _lidSwitchStateChangeNotificationHandle = RegisterPowerNotification(PInvoke.GUID_LIDSWITCH_STATE_CHANGE);
         _powerSavingStateChangeNotificationHandle = RegisterPowerNotification(PInvoke.GUID_POWER_SAVING_STATUS);
+        _activePowerSchemeNotificationHandle = RegisterPowerNotification(ActivePowerSchemeGuid);
 
         return EnsureInitializedAsync();
     });
@@ -102,10 +105,12 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
         PInvoke.UnregisterPowerSettingNotification(_consoleDisplayStateNotificationHandle);
         PInvoke.UnregisterPowerSettingNotification(_lidSwitchStateChangeNotificationHandle);
         PInvoke.UnregisterPowerSettingNotification(_powerSavingStateChangeNotificationHandle);
+        PInvoke.UnregisterPowerSettingNotification(_activePowerSchemeNotificationHandle);
 
         _kbHook = default;
         _deviceNotificationHandle = default;
         _consoleDisplayStateNotificationHandle = default;
+        _activePowerSchemeNotificationHandle = default;
 
         ReleaseHandle();
 
@@ -204,6 +209,13 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
                 Log.Instance.Trace($"Event received: Battery Saver enabled");
 
                 OnBatterySaverEnabled();
+            }
+
+            if (str.PowerSetting == ActivePowerSchemeGuid)
+            {
+                Log.Instance.Trace($"Event received: Active Power Scheme changed");
+
+                OnActivePowerSchemeChanged();
             }
         }
 
@@ -317,6 +329,21 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
         Task.Run(async () => await _powerModeFeature.EnsureCorrectWindowsPowerSettingsAreSetAsync().ConfigureAwait(false));
 
         RaiseChanged(NativeWindowsMessage.BatterySaverEnabled);
+    }
+
+    private void OnActivePowerSchemeChanged()
+    {
+        Task.Run(async () =>
+        {
+            try
+            {
+                await _powerModeFeature.EnsureCorrectPowerModeIsSetForActivePowerPlanAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                Log.Instance.Trace($"Failed to sync power mode from active power plan.", ex);
+            }
+        });
     }
 
     private void OnDeviceConnected(string name)

--- a/LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs
+++ b/LenovoLegionToolkit.Lib/Listeners/NativeWindowsMessageListener.cs
@@ -213,7 +213,7 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
 
             if (str.PowerSetting == ActivePowerSchemeGuid)
             {
-                Log.Instance.Trace($"Event received: Active Power Scheme changed");
+                Log.Instance.Trace($"Event received: Active Power Scheme Changed");
 
                 OnActivePowerSchemeChanged();
             }
@@ -341,7 +341,7 @@ public class NativeWindowsMessageListener : NativeWindow, IListener<NativeWindow
             }
             catch (Exception ex)
             {
-                Log.Instance.Trace($"Failed to sync power mode from active power plan.", ex);
+                Log.Instance.Trace($"Failed to synchronize power mode with active power plan.", ex);
             }
         });
     }

--- a/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
@@ -13,6 +13,7 @@ public class ApplicationSettings : AbstractSettings<ApplicationSettingsStore>
         public RGBColor? AccentColor { get; set; }
         public AccentColorSource AccentColorSource { get; set; }
         public PowerModeMappingMode PowerModeMappingMode { get; set; } = PowerModeMappingMode.Disabled;
+        public bool SynchronizePowerModeWithWindowsPowerPlan { get; set; }
         public Dictionary<PowerModeState, Guid> PowerPlans { get; set; } = [];
         public Dictionary<PowerModeState, WindowsPowerMode> PowerModes { get; set; } = [];
         public Dictionary<PowerModeState, Dictionary<PowerOverrideKey, string>> Overrides { get; set; } = [];

--- a/LenovoLegionToolkit.WPF/Controls/Settings/SettingsPowerControl.xaml
+++ b/LenovoLegionToolkit.WPF/Controls/Settings/SettingsPowerControl.xaml
@@ -56,6 +56,21 @@
                 Visibility="Collapsed">
                 <controls:CardHeaderControl Title="{x:Static resources:Resource.SettingsPage_WindowsPowerPlans_Title}" Subtitle="{x:Static resources:Resource.SettingsPage_WindowsPowerPlans_Message}" />
             </custom:CardAction>
+            <custom:CardControl
+                x:Name="_windowsPowerPlanSyncCard"
+                Margin="0,0,0,8"
+                Icon="Flash24"
+                Visibility="Collapsed">
+                <custom:CardControl.Header>
+                    <controls:CardHeaderControl Title="{x:Static resources:Resource.SettingsPage_WindowsPowerPlanSync_Title}" Subtitle="{x:Static resources:Resource.SettingsPage_WindowsPowerPlanSync_Message}" />
+                </custom:CardControl.Header>
+                <wpfui:ToggleSwitch
+                    x:Name="_windowsPowerPlanSyncToggle"
+                    Margin="0,0,0,8"
+                    AutomationProperties.Name="{x:Static resources:Resource.SettingsPage_WindowsPowerPlanSync_Title}"
+                    Click="WindowsPowerPlanSyncToggle_Click"
+                    Visibility="Hidden" />
+            </custom:CardControl>
             <custom:CardAction
                 x:Name="_windowsPowerPlansControlPanelCard"
                 Margin="0,0,0,8"

--- a/LenovoLegionToolkit.WPF/Controls/Settings/SettingsPowerControl.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Settings/SettingsPowerControl.xaml.cs
@@ -60,7 +60,7 @@ public partial class SettingsPowerControl
         _powerModeMappingCard.Visibility = isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _powerModesCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerMode && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
-        _windowsPowerPlanSyncCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
+        _windowsPowerPlanSyncCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isPowerModeFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansControlPanelCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
 
         if (isITSModeFeatureSupported && _settings.Store.PowerModeMappingMode != PowerModeMappingMode.Disabled)
@@ -111,7 +111,7 @@ public partial class SettingsPowerControl
         var isAnyPowerFeatureSupported = isPowerModeFeatureSupported || isITSModeFeatureSupported;
         _powerModesCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerMode && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
-        _windowsPowerPlanSyncCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
+        _windowsPowerPlanSyncCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isPowerModeFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansControlPanelCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
 
         if (isITSModeFeatureSupported && powerModeMappingMode != PowerModeMappingMode.Disabled)

--- a/LenovoLegionToolkit.WPF/Controls/Settings/SettingsPowerControl.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Settings/SettingsPowerControl.xaml.cs
@@ -60,6 +60,7 @@ public partial class SettingsPowerControl
         _powerModeMappingCard.Visibility = isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _powerModesCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerMode && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
+        _windowsPowerPlanSyncCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansControlPanelCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
 
         if (isITSModeFeatureSupported && _settings.Store.PowerModeMappingMode != PowerModeMappingMode.Disabled)
@@ -69,6 +70,8 @@ public partial class SettingsPowerControl
 
         _onBatterySinceResetToggle.IsChecked = _settings.Store.ResetBatteryOnSinceTimerOnReboot;
         _onBatterySinceResetToggle.Visibility = Visibility.Visible;
+        _windowsPowerPlanSyncToggle.IsChecked = _settings.Store.SynchronizePowerModeWithWindowsPowerPlan;
+        _windowsPowerPlanSyncToggle.Visibility = Visibility.Visible;
 
         _godModeFnQSwitchableToggle.Visibility = Visibility.Visible;
         _powerModeMappingComboBox.Visibility = Visibility.Visible;
@@ -108,6 +111,7 @@ public partial class SettingsPowerControl
         var isAnyPowerFeatureSupported = isPowerModeFeatureSupported || isITSModeFeatureSupported;
         _powerModesCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerMode && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
+        _windowsPowerPlanSyncCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansControlPanelCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
 
         if (isITSModeFeatureSupported && powerModeMappingMode != PowerModeMappingMode.Disabled)
@@ -140,6 +144,19 @@ public partial class SettingsPowerControl
     private void WindowsPowerPlansControlPanel_Click(object sender, RoutedEventArgs e)
     {
         Process.Start("control", "/name Microsoft.PowerOptions");
+    }
+
+    private void WindowsPowerPlanSyncToggle_Click(object sender, RoutedEventArgs e)
+    {
+        if (_isRefreshing)
+            return;
+
+        var state = _windowsPowerPlanSyncToggle.IsChecked;
+        if (state is null)
+            return;
+
+        _settings.Store.SynchronizePowerModeWithWindowsPowerPlan = state.Value;
+        _settings.SynchronizeStore();
     }
 
     private void OnBatterySinceResetToggle_Click(object sender, RoutedEventArgs e)

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -9567,6 +9567,24 @@ namespace LenovoLegionToolkit.WPF.Resources {
                 return ResourceManager.GetString("SettingsPage_WindowsPowerPlans_Title", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Change Power Mode when the active Windows Power Plan changes..
+        /// </summary>
+        public static string SettingsPage_WindowsPowerPlanSync_Message {
+            get {
+                return ResourceManager.GetString("SettingsPage_WindowsPowerPlanSync_Message", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sync Power Mode from Windows Power Plan.
+        /// </summary>
+        public static string SettingsPage_WindowsPowerPlanSync_Title {
+            get {
+                return ResourceManager.GetString("SettingsPage_WindowsPowerPlanSync_Title", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Power Plan options in Windows Control Panel.

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -3299,6 +3299,12 @@ If disabled, this app will handle Fn shortcuts.</value>
   <data name="SettingsPage_WindowsPowerPlans_Title" xml:space="preserve">
     <value>Windows Power Plans</value>
   </data>
+  <data name="SettingsPage_WindowsPowerPlanSync_Message" xml:space="preserve">
+    <value>Change Power Mode when the active Windows Power Plan changes.</value>
+  </data>
+  <data name="SettingsPage_WindowsPowerPlanSync_Title" xml:space="preserve">
+    <value>Sync Power Mode from Windows Power Plan</value>
+  </data>
   <data name="Settings_GodModeFnQSwitchable_Message" xml:space="preserve">
     <value>Allow quick switching to Custom Mode with Fn+Q.</value>
   </data>


### PR DESCRIPTION
## Description
Adds opt-in reverse synchronization for Windows Power Plans. When enabled, LLT listens for active Windows power plan changes, resolves the plan through the existing Power Mode mapping, and applies the mapped Lenovo Power Mode through the existing `PowerModeFeature.SetStateAsync` path.

Fixes #400

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility update (adding support for new hardware)
- [ ] Documentation update

## Hardware Verification Details
Since LLT interacts directly with BIOS and WMI, we require details on where this was tested.

- **Device Series:** Not verified on hardware by PR author
- **Exact Model Number:** Not verified on hardware by PR author
- **BIOS Version:** Not verified on hardware by PR author
- **Operating System:** Not verified on hardware by PR author

## Testing Checklist
- [ ] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [ ] I have verified this change on physical hardware.
- [ ] I have included a video/screenshot of the change in action (highly preferred for UI changes).
- [x] My code follows the project's style guidelines.

## Additional Notes
- Reverse sync is disabled by default and only available when Power Mode Synchronization is set to `Windows Power Plan`.
- `git diff --check` passes locally.
- Local build could not be run because this machine has only the .NET runtime installed, not the .NET SDK/MSBuild.
- The GitHub Actions build currently fails before compilation because forked PRs do not receive the `LLT_CERT_PFX` signing secret.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic synchronization between the active Windows power plan and the device power mode.
  * Power mode updates now occur when the active Windows power plan changes.
  * Added a setting to enable or disable Windows power-plan synchronization.
  * Added localized guidance for the synchronization option.
  * Synchronization safely handles unavailable, unsupported, or unmapped power plans.
  * Avoids unnecessary updates when the selected power mode is already correct.
  * Improved reliability when retrieving the active Windows power plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->