### PR TITLE
Fix IndexOutOfRangeException in RefreshRateFeature on Advanced Optimus devices

### DIFF
--- a/LenovoLegionToolkit.Lib/Extensions/DisplayExtensions.cs
+++ b/LenovoLegionToolkit.Lib/Extensions/DisplayExtensions.cs
@@ -144,7 +144,7 @@ public static class DisplayExtensions
         }
         catch (Exception ex)
         {
-            Log.Instance.Trace($"SetSettingsUsingPathInfoAsync failed: {ex.Message}. Falling back to DisplayScreen.SetSettings.");
+            Log.Instance.Trace($"SetSettingsUsingPathInfoAsync failed. Falling back to DisplayScreen.SetSettings.", ex);
             display.DisplayScreen.SetSettings(displaySetting, apply: true);
         }
     }

--- a/LenovoLegionToolkit.Lib/Extensions/DisplayExtensions.cs
+++ b/LenovoLegionToolkit.Lib/Extensions/DisplayExtensions.cs
@@ -18,133 +18,133 @@ public static class DisplayExtensions
 
     public static async Task SetSettingsUsingPathInfoAsync(this Display display, DisplaySetting displaySetting, bool enableDrr = false, int physicalFrequency = 0)
     {
-        var displaySource = display.DisplayScreen.ToPathDisplaySource();
-        var pathInfos = PathInfo.GetActivePaths(virtualModeAware: true);
-
-        var targetInfo = pathInfos
-            .Where(p => p.DisplaySource == displaySource)
-            .SelectMany(p => p.TargetsInfo)
-            .FirstOrDefault();
-
-        var maxFrequency = display.DisplayScreen.GetPossibleSettings()
-            .Select(dps => dps.Frequency)
-            .DefaultIfEmpty(0)
-            .Max();
-        var targetPhysicalFreq = physicalFrequency > 0 ? physicalFrequency : maxFrequency;
-
-        var currentPhysicalFreq = targetInfo != null
-            ? (targetInfo.IsSignalInformationAvailable
-                ? (int)(targetInfo.SignalInfo.VerticalSyncFrequencyInMillihertz / 1000)
-                : (int)(targetInfo.FrequencyInMillihertz / 1000))
-            : 0;
-
-        var needsPreInit = enableDrr && maxFrequency > 0 && (
-            targetInfo == null ||
-            !targetInfo.IsDesktopImageInformationAvailable ||
-            (physicalFrequency > 0 && (!targetInfo.IsBoostRefreshRate || currentPhysicalFreq != physicalFrequency))
-        );
-
-        if (needsPreInit)
+        try
         {
-            Log.Instance.Trace($"DRR pre-initialization required. Setting display to physical frequency {targetPhysicalFreq}Hz...");
-            var physicalSetting = new DisplaySetting(
-                displaySetting.Resolution,
-                displaySetting.Position,
-                displaySetting.ColorDepth,
-                targetPhysicalFreq,
-                displaySetting.IsInterlaced,
-                displaySetting.Orientation,
-                displaySetting.OutputScalingMode
+            var displaySource = display.DisplayScreen.ToPathDisplaySource();
+            var pathInfos = PathInfo.GetActivePaths(virtualModeAware: true);
+
+            var targetInfo = pathInfos
+                .Where(p => p.DisplaySource == displaySource)
+                .SelectMany(p => p.TargetsInfo)
+                .FirstOrDefault();
+
+            var maxFrequency = display.DisplayScreen.GetPossibleSettings()
+                .Select(dps => dps.Frequency)
+                .DefaultIfEmpty(0)
+                .Max();
+            var targetPhysicalFreq = physicalFrequency > 0 ? physicalFrequency : maxFrequency;
+
+            var currentPhysicalFreq = targetInfo != null
+                ? (targetInfo.IsSignalInformationAvailable
+                    ? (int)(targetInfo.SignalInfo.VerticalSyncFrequencyInMillihertz / 1000)
+                    : (int)(targetInfo.FrequencyInMillihertz / 1000))
+                : 0;
+
+            var needsPreInit = enableDrr && maxFrequency > 0 && (
+                targetInfo == null ||
+                !targetInfo.IsDesktopImageInformationAvailable ||
+                (physicalFrequency > 0 && (!targetInfo.IsBoostRefreshRate || currentPhysicalFreq != physicalFrequency))
             );
-            display.DisplayScreen.SetSettings(physicalSetting, apply: true);
 
-            var stabilized = false;
-            for (var attempt = 0; attempt < DrrPreInitAttempts; attempt++)
+            if (needsPreInit)
             {
-                await Task.Delay(DrrPreInitDelayMs).ConfigureAwait(false);
-                pathInfos = PathInfo.GetActivePaths(virtualModeAware: true);
-                targetInfo = pathInfos
-                    .Where(p => p.DisplaySource == displaySource)
-                    .SelectMany(p => p.TargetsInfo)
-                    .FirstOrDefault();
+                Log.Instance.Trace($"DRR pre-initialization required. Setting display to physical frequency {targetPhysicalFreq}Hz...");
+                var physicalSetting = new DisplaySetting(
+                    displaySetting.Resolution,
+                    displaySetting.Position,
+                    displaySetting.ColorDepth,
+                    targetPhysicalFreq,
+                    displaySetting.IsInterlaced,
+                    displaySetting.Orientation,
+                    displaySetting.OutputScalingMode
+                );
+                display.DisplayScreen.SetSettings(physicalSetting, apply: true);
 
-                var isSignalAvailable = targetInfo?.IsSignalInformationAvailable == true;
-                var loopPhysicalFreq = isSignalAvailable ? (int)(targetInfo!.SignalInfo!.VerticalSyncFrequencyInMillihertz / 1000) : 0;
-
-                if (targetInfo != null && isSignalAvailable && loopPhysicalFreq == targetPhysicalFreq)
+                var stabilized = false;
+                for (var attempt = 0; attempt < DrrPreInitAttempts; attempt++)
                 {
-                    Log.Instance.Trace($"DRR pre-initialization stabilized at {loopPhysicalFreq}Hz in {(attempt + 1) * DrrPreInitDelayMs}ms.");
-                    stabilized = true;
-                    break;
+                    await Task.Delay(DrrPreInitDelayMs).ConfigureAwait(false);
+                    pathInfos = PathInfo.GetActivePaths(virtualModeAware: true);
+                    targetInfo = pathInfos
+                        .Where(p => p.DisplaySource == displaySource)
+                        .SelectMany(p => p.TargetsInfo)
+                        .FirstOrDefault();
+
+                    var isSignalAvailable = targetInfo?.IsSignalInformationAvailable == true;
+                    var loopPhysicalFreq = isSignalAvailable ? (int)(targetInfo!.SignalInfo!.VerticalSyncFrequencyInMillihertz / 1000) : 0;
+
+                    if (targetInfo != null && isSignalAvailable && loopPhysicalFreq == targetPhysicalFreq)
+                    {
+                        Log.Instance.Trace($"DRR pre-initialization stabilized at {loopPhysicalFreq}Hz in {(attempt + 1) * DrrPreInitDelayMs}ms.");
+                        stabilized = true;
+                        break;
+                    }
+                }
+
+                if (!stabilized)
+                {
+                    Log.Instance.Trace($"DRR pre-initialization stabilization timed out after 1 second.");
                 }
             }
 
-            if (!stabilized)
+            for (var i = 0; i < pathInfos.Length; i++)
             {
-                Log.Instance.Trace($"DRR pre-initialization stabilization timed out after 1 second.");
-            }
-        }
+                var pathInfo = pathInfos[i];
 
-        for (var i = 0; i < pathInfos.Length; i++)
-        {
-            var pathInfo = pathInfos[i];
-
-            if (pathInfo.DisplaySource == displaySource)
-            {
-                var targetsInfo = pathInfo.TargetsInfo;
-                var pathTargetInfos = targetsInfo
-                    .Select(target =>
-                    {
-                        if (enableDrr && target.IsVirtualModeSupportedByPath)
+                if (pathInfo.DisplaySource == displaySource)
+                {
+                    var targetsInfo = pathInfo.TargetsInfo;
+                    var pathTargetInfos = targetsInfo
+                        .Select(target =>
                         {
-                            var virtualFreqMillihertz = (ulong)(displaySetting.Frequency * 1000);
-                            var size = new global::System.Drawing.Size(displaySetting.Resolution.Width, displaySetting.Resolution.Height);
-                            var rect = new global::System.Drawing.Rectangle(0, 0, displaySetting.Resolution.Width, displaySetting.Resolution.Height);
-                            var desktopImage = new PathTargetDesktopImage(size, rect, rect);
+                            if (enableDrr && target.IsVirtualModeSupportedByPath)
+                            {
+                                var virtualFreqMillihertz = (ulong)(displaySetting.Frequency * 1000);
+                                var size = new global::System.Drawing.Size(displaySetting.Resolution.Width, displaySetting.Resolution.Height);
+                                var rect = new global::System.Drawing.Rectangle(0, 0, displaySetting.Resolution.Width, displaySetting.Resolution.Height);
+                                var desktopImage = new PathTargetDesktopImage(size, rect, rect);
 
-                            return new PathTargetInfo(
-                                target.DisplayTarget,
-                                target.SignalInfo!,
-                                desktopImage,
-                                target.Rotation,
-                                target.Scaling,
-                                target.IsVirtualModeSupportedByPath,
-                                true,
-                                virtualFreqMillihertz
-                            );
-                        }
-                        else
-                        {
-                            var staticSignalInfo = new PathTargetSignalInfo(displaySetting, displaySetting.Resolution);
-                            return new PathTargetInfo(
-                                target.DisplayTarget,
-                                staticSignalInfo,
-                                target.Rotation,
-                                target.Scaling,
-                                target.IsVirtualModeSupportedByPath,
-                                false
-                            );
-                        }
-                    })
-                    .ToArray();
+                                return new PathTargetInfo(
+                                    target.DisplayTarget,
+                                    target.SignalInfo!,
+                                    desktopImage,
+                                    target.Rotation,
+                                    target.Scaling,
+                                    target.IsVirtualModeSupportedByPath,
+                                    true,
+                                    virtualFreqMillihertz
+                                );
+                            }
+                            else
+                            {
+                                var staticSignalInfo = new PathTargetSignalInfo(displaySetting, displaySetting.Resolution);
+                                return new PathTargetInfo(
+                                    target.DisplayTarget,
+                                    staticSignalInfo,
+                                    target.Rotation,
+                                    target.Scaling,
+                                    target.IsVirtualModeSupportedByPath,
+                                    false
+                                );
+                            }
+                        })
+                        .ToArray();
 
-                pathInfos[i] = new PathInfo(
-                    pathInfo.DisplaySource,
-                    pathInfo.Position,
-                    displaySetting.Resolution,
-                    pathInfo.PixelFormat,
-                    pathTargetInfos
-                );
+                    pathInfos[i] = new PathInfo(
+                        pathInfo.DisplaySource,
+                        pathInfo.Position,
+                        displaySetting.Resolution,
+                        pathInfo.PixelFormat,
+                        pathTargetInfos
+                    );
+                }
             }
-        }
 
-        try
-        {
             PathInfo.ApplyPathInfos(pathInfos, saveToDatabase: true);
         }
         catch (Exception ex)
         {
-            Log.Instance.Trace($"ApplyPathInfos failed: {ex.Message}. Falling back to DisplayScreen.SetSettings.");
+            Log.Instance.Trace($"SetSettingsUsingPathInfoAsync failed: {ex.Message}. Falling back to DisplayScreen.SetSettings.");
             display.DisplayScreen.SetSettings(displaySetting, apply: true);
         }
     }

--- a/LenovoLegionToolkit.Lib/Features/RefreshRateFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/RefreshRateFeature.cs
@@ -47,12 +47,19 @@ public class RefreshRateFeature : IFeature<RefreshRate>
             var maxFreq = result.Max(r => r.Frequency);
             if (maxFreq > MinimumDrrFrequency)
             {
-                var displaySource = display.DisplayScreen.ToPathDisplaySource();
-                var pathInfos = WindowsDisplayAPI.DisplayConfig.PathInfo.GetActivePaths(virtualModeAware: true);
-                var activePath = pathInfos.FirstOrDefault(p => p.DisplaySource == displaySource);
-                if (activePath is not null && activePath.TargetsInfo.Any(t => t.IsVirtualModeSupportedByPath))
+                try
                 {
-                    result.Add(new RefreshRate(maxFreq, isDynamic: true));
+                    var displaySource = display.DisplayScreen.ToPathDisplaySource();
+                    var pathInfos = WindowsDisplayAPI.DisplayConfig.PathInfo.GetActivePaths(virtualModeAware: true);
+                    var activePath = pathInfos.FirstOrDefault(p => p.DisplaySource == displaySource);
+                    if (activePath is not null && activePath.TargetsInfo.Any(t => t.IsVirtualModeSupportedByPath))
+                    {
+                        result.Add(new RefreshRate(maxFreq, isDynamic: true));
+                    }
+                }
+                catch (Exception ex)
+                {
+                    Log.Instance.Trace($"Failed to query virtual mode support for DRR: {ex.Message}");
                 }
             }
         }
@@ -74,34 +81,41 @@ public class RefreshRateFeature : IFeature<RefreshRate>
             return default(RefreshRate);
         }
 
-        var displaySource = display.DisplayScreen.ToPathDisplaySource();
-        var pathInfos = WindowsDisplayAPI.DisplayConfig.PathInfo.GetActivePaths(virtualModeAware: true);
-        var activePath = pathInfos.FirstOrDefault(p => p.DisplaySource == displaySource);
-        if (activePath is not null)
+        try
         {
-            var target = activePath.TargetsInfo.FirstOrDefault(t => t.IsCurrentlyInUse || t.IsPathActive);
-            if (target is not null)
+            var displaySource = display.DisplayScreen.ToPathDisplaySource();
+            var pathInfos = WindowsDisplayAPI.DisplayConfig.PathInfo.GetActivePaths(virtualModeAware: true);
+            var activePath = pathInfos.FirstOrDefault(p => p.DisplaySource == displaySource);
+            if (activePath is not null)
             {
-                if (target.IsBoostRefreshRate)
+                var target = activePath.TargetsInfo.FirstOrDefault(t => t.IsCurrentlyInUse || t.IsPathActive);
+                if (target is not null)
                 {
-                    var currentSettings = display.DisplayScreen.CurrentSetting;
-                    var maxFreq = display.DisplayScreen.GetPossibleSettings()
-                        .Where(dps => Match(dps, currentSettings))
-                        .Select(dps => dps.Frequency)
-                        .DefaultIfEmpty(MinimumDrrFrequency)
-                        .Max();
-                    var drrResult = new RefreshRate(maxFreq, isDynamic: true);
-                    Log.Instance.Trace($"Dynamic Refresh Rate (DRR) is active. Reporting rate: {drrResult}");
-                    return drrResult;
+                    if (target.IsBoostRefreshRate)
+                    {
+                        var currentSettings = display.DisplayScreen.CurrentSetting;
+                        var maxFreq = display.DisplayScreen.GetPossibleSettings()
+                            .Where(dps => Match(dps, currentSettings))
+                            .Select(dps => dps.Frequency)
+                            .DefaultIfEmpty(MinimumDrrFrequency)
+                            .Max();
+                        var drrResult = new RefreshRate(maxFreq, isDynamic: true);
+                        Log.Instance.Trace($"Dynamic Refresh Rate (DRR) is active. Reporting rate: {drrResult}");
+                        return drrResult;
+                    }
+
+                    var freq = (int)(target.FrequencyInMillihertz / 1000);
+                    var result = new RefreshRate(freq);
+
+                    Log.Instance.Trace($"Current refresh rate is {result}");
+
+                    return result;
                 }
-
-                var freq = (int)(target.FrequencyInMillihertz / 1000);
-                var result = new RefreshRate(freq);
-
-                Log.Instance.Trace($"Current refresh rate is {result}");
-
-                return result;
             }
+        }
+        catch (Exception ex)
+        {
+            Log.Instance.Trace($"Failed to query active path refresh rate: {ex.Message}");
         }
 
         var currentSettingsFallback = display.DisplayScreen.CurrentSetting;

--- a/LenovoLegionToolkit.Lib/Features/RefreshRateFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/RefreshRateFeature.cs
@@ -59,7 +59,7 @@ public class RefreshRateFeature : IFeature<RefreshRate>
                 }
                 catch (Exception ex)
                 {
-                    Log.Instance.Trace($"Failed to query virtual mode support for DRR: {ex.Message}");
+                    Log.Instance.Trace($"Failed to query virtual mode support for DRR", ex);
                 }
             }
         }
@@ -115,7 +115,7 @@ public class RefreshRateFeature : IFeature<RefreshRate>
         }
         catch (Exception ex)
         {
-            Log.Instance.Trace($"Failed to query active path refresh rate: {ex.Message}");
+            Log.Instance.Trace($"Failed to query active path refresh rate", ex);
         }
 
         var currentSettingsFallback = display.DisplayScreen.CurrentSetting;

--- a/LenovoLegionToolkit.WPF/Controls/Automation/AbstractAutomationStepControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Automation/AbstractAutomationStepControl.cs
@@ -1,9 +1,10 @@
-﻿ using System;
+using System;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
 using System.Windows.Controls;
 using LenovoLegionToolkit.Lib.Automation.Steps;
+using LenovoLegionToolkit.Lib.Utils;
 using LenovoLegionToolkit.WPF.Resources;
 using Wpf.Ui.Common;
 using Wpf.Ui.Controls;
@@ -154,8 +155,15 @@ public abstract class AbstractAutomationStepControl : UserControl
 
     private async void RefreshingControl_Loaded(object sender, RoutedEventArgs e)
     {
-        await RefreshAsync();
-        OnFinishedLoading();
+        try
+        {
+            await RefreshAsync();
+            OnFinishedLoading();
+        }
+        catch (Exception ex)
+        {
+            Log.Instance.Trace($"Error loading automation step control {GetType().Name}", ex);
+        }
     }
 
     public abstract IAutomationStep CreateAutomationStep();

--- a/LenovoLegionToolkit.WPF/Controls/Automation/AbstractAutomationStepControl.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Automation/AbstractAutomationStepControl.cs
@@ -158,11 +158,14 @@ public abstract class AbstractAutomationStepControl : UserControl
         try
         {
             await RefreshAsync();
-            OnFinishedLoading();
         }
         catch (Exception ex)
         {
             Log.Instance.Trace($"Error loading automation step control {GetType().Name}", ex);
+        }
+        finally
+        {
+            OnFinishedLoading();
         }
     }
 


### PR DESCRIPTION
# Pull Request

## Description
Fixes an unhandled `System.IndexOutOfRangeException` when querying or setting refresh rates on devices with Dynamic Display Switching / Advanced Optimus / virtual mode paths (e.g. Legion 7 16IRX9).

### Problem
`WindowsDisplayAPI.DisplayConfig.PathInfo.GetPathInfos` accesses `displayModes[...]` using path mode indices without checking array bounds. On Advanced Optimus / hybrid GPU configurations, Windows CCD APIs return mode indices that exceed `displayModes.Length`, throwing an unhandled `IndexOutOfRangeException` during `PathInfo.GetActivePaths(virtualModeAware: true)`. This causes `RefreshRateFeature.GetAllStatesAsync()` and `RefreshingControl_Loaded` in automation step cards & dashboard to crash, making Refresh Rate unable to change.

<img width="3199" height="1886" alt="image" src="https://github.com/user-attachments/assets/b08f1204-699a-4f1c-ba1b-a21bf1c7cdc6" />

### Solution
1. **[RefreshRateFeature.cs]**:
   - Wrapped `PathInfo.GetActivePaths(virtualModeAware: true)` DRR checks in `GetAllStatesAsync` inside a `try-catch` block so standard display settings enumeration continues reliably.
   - Added `try-catch` error handling in `GetStateAsync` with fallback to `DisplayScreen.CurrentSetting.Frequency`.
2. **[DisplayExtensions.cs]**:
   - Enclosed `SetSettingsUsingPathInfoAsync` in a `try-catch` block to safely fallback to standard `DisplayScreen.SetSettings()` (`ChangeDisplaySettingsEx`) if `PathInfo` operations fail.
3. **[AbstractAutomationStepControl.cs]**:
   - Wrapped `RefreshingControl_Loaded` in `try-catch` to protect the WPF Dispatcher against unhandled `async void` exceptions during control initialization.

## Fixes
```
System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at WindowsDisplayAPI.DisplayConfig.PathInfo.GetPathInfos(QueryDeviceConfigFlags flags, DisplayConfigTopologyId& topologyId)
   at WindowsDisplayAPI.DisplayConfig.PathInfo.GetActivePaths(Boolean virtualModeAware)
   at LenovoLegionToolkit.Lib.Features.RefreshRateFeature.GetAllStatesAsync()
   at LenovoLegionToolkit.WPF.Controls.Automation.AbstractComboBoxAutomationStepCardControl`1.RefreshAsync()
   at LenovoLegionToolkit.WPF.Controls.Automation.AbstractAutomationStepControl.RefreshingControl_Loaded(Object sender, RoutedEventArgs e)
   at System.Threading.Tasks.Task.<>c.<ThrowAsync>b__128_0(Object state)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```
## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Compatibility update (adding support for new hardware)
- [ ] Documentation update

## Hardware Verification Details
- **Device Series:** Legion 7
- **Exact Model Number:** Legion 7 16IRX9 (Machine Type: 83FD)
- **BIOS Version:** P05AMA.041.250608.SX
- **Operating System:** Windows 11

## Testing Checklist
- [x] I have enabled logging in **Settings** and verified the logs show no WMI/ACPI errors.
- [x] I have verified this change on physical hardware.
- [x] I have included a video/screenshot of the change in action.
- [x] My code follows the project's style guidelines.

## Additional Notes
Tested on Legion 7 16IRX9 (Gen 9) with Advanced Optimus and 3.2K 165Hz display. Refresh rates now populate properly in the UI and Automation settings without crashing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved display settings and refresh-rate handling when dynamic refresh-rate information is unavailable or encounters an error.
  * Added safer fallback behavior to use the display’s current settings when detection fails.
  * Prevented automation controls from failing unexpectedly during refresh operations.
  * Ensured automation screens finish loading even when a refresh encounters an error.
  * Added error logging to help diagnose display and automation issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->