### PR TITLE
Preserve unmapped power plans on AC changes

### DIFF
--- a/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
+++ b/LenovoLegionToolkit.Lib/Controllers/WindowsPowerPlanController.cs
@@ -34,7 +34,7 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
         }
     }
 
-    public async Task SetPowerPlanAsync(PowerModeState powerModeState, bool alwaysActivateDefaults = false, GodModeSettingsStore.Preset? preset = null, bool skipThrottle = false)
+    public async Task SetPowerPlanAsync(PowerModeState powerModeState, bool alwaysActivateDefaults = false, GodModeSettingsStore.Preset? preset = null, bool skipThrottle = false, bool preserveUnmappedActivePlan = false)
     {
         await _lock.WaitAsync().ConfigureAwait(false);
         try
@@ -74,6 +74,9 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
 
             var powerPlans = GetPowerPlans().ToArray();
 
+            if (preserveUnmappedActivePlan && ShouldPreserveUnmappedActivePlan(powerPlans))
+                return;
+
             Log.Instance.Trace($"Available power plans:");
             foreach (var powerPlan in powerPlans)
                 Log.Instance.Trace($" - {powerPlan}");
@@ -110,6 +113,24 @@ public class WindowsPowerPlanController(ApplicationSettings settings, VantageDis
         {
             _lock.Release();
         }
+    }
+
+    private bool ShouldPreserveUnmappedActivePlan(IEnumerable<WindowsPowerPlan> powerPlans)
+    {
+        if (!settings.Store.PreserveUnmappedPowerPlanOnAcDcChange)
+            return false;
+
+        var activePowerPlan = powerPlans.FirstOrDefault(powerPlan => powerPlan.IsActive);
+        if (activePowerPlan.Guid == Guid.Empty || activePowerPlan.Guid == DefaultPowerPlan)
+            return false;
+
+        var isMapped = settings.Store.PowerPlans.ContainsValue(activePowerPlan.Guid) ||
+                       settings.Store.ITSPowerPlans.ContainsValue(activePowerPlan.Guid);
+        if (isMapped)
+            return false;
+
+        Log.Instance.Trace($"Preserving active unmapped power plan. [guid={activePowerPlan.Guid}, name={activePowerPlan.Name}]");
+        return true;
     }
 
     private async Task ApplyBalanceOverlayIfNeededAsync(Guid activePowerPlanGuid, PowerModeState powerModeState, bool isDefault, GodModeSettingsStore.Preset? preset = null, bool skipThrottle = false)

--- a/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
+++ b/LenovoLegionToolkit.Lib/Features/PowerModeFeature.cs
@@ -123,19 +123,19 @@ public class PowerModeFeature(
         await SetStateAsync(state).ConfigureAwait(false);
     }
 
-    public async Task EnsureCorrectWindowsPowerSettingsAreSetAsync(GodModeSettingsStore.Preset? preset = null, bool skipThrottle = false)
+    public async Task EnsureCorrectWindowsPowerSettingsAreSetAsync(GodModeSettingsStore.Preset? preset = null, bool skipThrottle = false, bool preserveUnmappedActivePlan = false)
     {
         var state = await GetStateAsync().ConfigureAwait(false);
         await windowsPowerModeController.SetPowerModeAsync(state, preset, skipThrottle).ConfigureAwait(false);
-        await windowsPowerPlanController.SetPowerPlanAsync(state, true, preset, skipThrottle).ConfigureAwait(false);
+        await windowsPowerPlanController.SetPowerPlanAsync(state, true, preset, skipThrottle, preserveUnmappedActivePlan).ConfigureAwait(false);
     }
 
-    public async Task EnsureGodModeStateIsAppliedAsync()
+    public async Task EnsureGodModeStateIsAppliedAsync(bool preserveUnmappedActivePlan = false)
     {
         var state = await GetStateAsync().ConfigureAwait(false);
         if (state != PowerModeState.GodMode)
         {
-            await EnsureCorrectWindowsPowerSettingsAreSetAsync().ConfigureAwait(false);
+            await EnsureCorrectWindowsPowerSettingsAreSetAsync(preserveUnmappedActivePlan: preserveUnmappedActivePlan).ConfigureAwait(false);
             return;
         }
 

--- a/LenovoLegionToolkit.Lib/Listeners/PowerStateListener.cs
+++ b/LenovoLegionToolkit.Lib/Listeners/PowerStateListener.cs
@@ -274,7 +274,7 @@ public sealed class PowerStateListener : IListener<PowerStateListener.ChangedEve
     {
         if (await _powerModeFeature.IsSupportedAsync().ConfigureAwait(false))
         {
-            await _powerModeFeature.EnsureGodModeStateIsAppliedAsync().ConfigureAwait(false);
+            await _powerModeFeature.EnsureGodModeStateIsAppliedAsync(preserveUnmappedActivePlan: true).ConfigureAwait(false);
         }
 
         _ = NotifyDgpuAsync();

--- a/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
+++ b/LenovoLegionToolkit.Lib/Settings/ApplicationSettings.cs
@@ -16,6 +16,7 @@ public class ApplicationSettings : AbstractSettings<ApplicationSettingsStore>
         public Dictionary<PowerModeState, Guid> PowerPlans { get; set; } = [];
         public Dictionary<PowerModeState, WindowsPowerMode> PowerModes { get; set; } = [];
         public Dictionary<PowerModeState, Dictionary<PowerOverrideKey, string>> Overrides { get; set; } = [];
+        public bool PreserveUnmappedPowerPlanOnAcDcChange { get; set; }
 
         public Dictionary<ITSMode, Guid> ITSPowerPlans { get; set; } = [];
         public Dictionary<ITSMode, WindowsPowerMode> ITSPowerModes { get; set; } = [];

--- a/LenovoLegionToolkit.WPF/Controls/Settings/SettingsPowerControl.xaml
+++ b/LenovoLegionToolkit.WPF/Controls/Settings/SettingsPowerControl.xaml
@@ -56,6 +56,21 @@
                 Visibility="Collapsed">
                 <controls:CardHeaderControl Title="{x:Static resources:Resource.SettingsPage_WindowsPowerPlans_Title}" Subtitle="{x:Static resources:Resource.SettingsPage_WindowsPowerPlans_Message}" />
             </custom:CardAction>
+            <custom:CardControl
+                x:Name="_preserveUnmappedPowerPlanCard"
+                Margin="0,0,0,8"
+                Icon="PlugDisconnected24"
+                Visibility="Collapsed">
+                <custom:CardControl.Header>
+                    <controls:CardHeaderControl Title="{x:Static resources:Resource.SettingsPage_PreserveUnmappedPowerPlan_Title}" Subtitle="{x:Static resources:Resource.SettingsPage_PreserveUnmappedPowerPlan_Message}" />
+                </custom:CardControl.Header>
+                <wpfui:ToggleSwitch
+                    x:Name="_preserveUnmappedPowerPlanToggle"
+                    Margin="0,0,0,8"
+                    AutomationProperties.Name="{x:Static resources:Resource.SettingsPage_PreserveUnmappedPowerPlan_Title}"
+                    Click="PreserveUnmappedPowerPlanToggle_Click"
+                    Visibility="Hidden" />
+            </custom:CardControl>
             <custom:CardAction
                 x:Name="_windowsPowerPlansControlPanelCard"
                 Margin="0,0,0,8"

--- a/LenovoLegionToolkit.WPF/Controls/Settings/SettingsPowerControl.xaml.cs
+++ b/LenovoLegionToolkit.WPF/Controls/Settings/SettingsPowerControl.xaml.cs
@@ -60,6 +60,7 @@ public partial class SettingsPowerControl
         _powerModeMappingCard.Visibility = isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _powerModesCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerMode && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
+        _preserveUnmappedPowerPlanCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isPowerModeFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansControlPanelCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
 
         if (isITSModeFeatureSupported && _settings.Store.PowerModeMappingMode != PowerModeMappingMode.Disabled)
@@ -69,6 +70,9 @@ public partial class SettingsPowerControl
 
         _onBatterySinceResetToggle.IsChecked = _settings.Store.ResetBatteryOnSinceTimerOnReboot;
         _onBatterySinceResetToggle.Visibility = Visibility.Visible;
+
+        _preserveUnmappedPowerPlanToggle.IsChecked = _settings.Store.PreserveUnmappedPowerPlanOnAcDcChange;
+        _preserveUnmappedPowerPlanToggle.Visibility = Visibility.Visible;
 
         _godModeFnQSwitchableToggle.Visibility = Visibility.Visible;
         _powerModeMappingComboBox.Visibility = Visibility.Visible;
@@ -108,6 +112,7 @@ public partial class SettingsPowerControl
         var isAnyPowerFeatureSupported = isPowerModeFeatureSupported || isITSModeFeatureSupported;
         _powerModesCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerMode && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
+        _preserveUnmappedPowerPlanCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isPowerModeFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
         _windowsPowerPlansControlPanelCard.Visibility = _settings.Store.PowerModeMappingMode == PowerModeMappingMode.WindowsPowerPlan && isAnyPowerFeatureSupported ? Visibility.Visible : Visibility.Collapsed;
 
         if (isITSModeFeatureSupported && powerModeMappingMode != PowerModeMappingMode.Disabled)
@@ -152,6 +157,19 @@ public partial class SettingsPowerControl
             return;
 
         _settings.Store.ResetBatteryOnSinceTimerOnReboot = state.Value;
+        _settings.SynchronizeStore();
+    }
+
+    private void PreserveUnmappedPowerPlanToggle_Click(object sender, RoutedEventArgs e)
+    {
+        if (_isRefreshing)
+            return;
+
+        var state = _preserveUnmappedPowerPlanToggle.IsChecked;
+        if (state is null)
+            return;
+
+        _settings.Store.PreserveUnmappedPowerPlanOnAcDcChange = state.Value;
         _settings.SynchronizeStore();
     }
 }

--- a/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.Designer.cs
@@ -9438,6 +9438,23 @@ namespace LenovoLegionToolkit.WPF.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Keep an active Windows power plan that is not mapped to a power mode when AC adapter state changes..
+        /// </summary>
+        public static string SettingsPage_PreserveUnmappedPowerPlan_Message {
+            get {
+                return ResourceManager.GetString("SettingsPage_PreserveUnmappedPowerPlan_Message", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Preserve custom power plan.
+        /// </summary>
+        public static string SettingsPage_PreserveUnmappedPowerPlan_Title {
+            get {
+                return ResourceManager.GetString("SettingsPage_PreserveUnmappedPowerPlan_Title", resourceCulture);
+            }
+        }
+                /// <summary>
         ///   查找类似 Are you sure you want to reset all settings to defaults? This action cannot be undone and the application will restart. 的本地化字符串。
         /// </summary>
         public static string SettingsPage_ResetSettings_Confirm {

--- a/LenovoLegionToolkit.WPF/Resources/Resource.resx
+++ b/LenovoLegionToolkit.WPF/Resources/Resource.resx
@@ -3261,6 +3261,12 @@ If disabled, this app will handle Fn shortcuts.</value>
   <data name="SettingsPage_RememberWindowPosition_Title" xml:space="preserve">
     <value>Remember Window Position</value>
   </data>
+  <data name="SettingsPage_PreserveUnmappedPowerPlan_Message" xml:space="preserve">
+    <value>Keep an active Windows power plan that is not mapped to a power mode when AC adapter state changes.</value>
+  </data>
+  <data name="SettingsPage_PreserveUnmappedPowerPlan_Title" xml:space="preserve">
+    <value>Preserve custom power plan</value>
+  </data>
   <data name="SettingsPage_ResetSettings_Confirm" xml:space="preserve">
     <value>Are you sure you want to reset all settings to defaults? This action cannot be undone and the application will restart.</value>
   </data>


### PR DESCRIPTION
## Summary\n- add an opt-in Power setting to preserve an active unmapped custom Windows power plan when LLT handles an AC adapter connection\n- keep existing mapped-plan behavior for Fn+Q and other explicit power-mode changes\n- do not preserve Windows Balanced or any plan configured in Power Mode/ITS mappings\n\n## Verification\n- git diff --check\n- static wiring check for the setting, AC handler, and generated resources\n- build not run: this machine has no .NET SDK installed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to preserve an unmapped Windows power plan when switching between AC and battery power.
  - Added localized title and description text for the new setting.
  - The option appears when supported by the device’s power-plan configuration.

- **Bug Fixes**
  - Prevents supported power-mode synchronization from unexpectedly replacing preserved, unmapped power plans during power-source changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->